### PR TITLE
fix: lockAndVerify timestamp arg to LockedOGTemple.lockFor

### DIFF
--- a/apps/protocol/contracts/LockedOGTemple.sol
+++ b/apps/protocol/contracts/LockedOGTemple.sol
@@ -28,10 +28,14 @@ contract LockedOGTemple {
         ogTempleToken = _ogTempleToken;
     }
 
-    /** lock up OG */
+    /**
+    * _staker: address of staker
+    * _amountOGTemple: OGTEMPLE to lock
+    * _unlockDelaySeconds: Delay to add to block.timestamp will pick max btw block.timestamp + _unlockDelaySeconds > lockEntry.lockedUntilTimestamp
+    */
     function lockFor(address _staker, uint256 _amountOGTemple, uint256 _unlockDelaySeconds) public {
         LockedEntry storage lockEntry = ogTempleLocked[_staker];
-        
+
         lockEntry.amount += _amountOGTemple;
         uint256 newLockedUntilTimestamp = block.timestamp + _unlockDelaySeconds;
         if (newLockedUntilTimestamp > lockEntry.lockedUntilTimestamp) {

--- a/apps/protocol/contracts/devotion/Devotion.sol
+++ b/apps/protocol/contracts/devotion/Devotion.sol
@@ -184,8 +184,7 @@ contract Devotion is Ownable {
         require(verifiedFaith[currentRound][msg.sender] == false, "!VERIFY: ALREADY CLAIMED");
 
         // If relocking new OG-Temple
-        uint256 lockedUntilTimestamp = block.timestamp + minimumLockPeriod;
-        lockedOGTemple.lockFor(msg.sender, amountOGTemple, lockedUntilTimestamp); // If already locked for longer will use the Max
+        lockedOGTemple.lockFor(msg.sender, amountOGTemple, minimumLockPeriod); // If already locked for longer will use the Max
         (uint256 lockedOGTempleAmount,  uint256 newLockedUntilTimestamp) = lockedOGTemple.ogTempleLocked(msg.sender);
         uint256 claimableFaith = lockedOGTempleAmount / 10**18; // Will round out
         require(claimableFaith > 0, "NO CLAIMABLE FAITH");


### PR DESCRIPTION
Previous impl was doubling the `block.timestamp` in `Devotion.sol::lockAndVerify`