### PR TITLE
add yarnrc file

### DIFF
--- a/.yarnrc
+++ b/.yarnrc
@@ -1,0 +1,1 @@
+--install.frozen-lockfile true


### PR DESCRIPTION
Add a .yarnrc file that contains --install.frozen-lockfile true. This forces yarn to behave consistently when doing an initial yarn install, otherwise it will try to "optimize" the lock file and change it.


Reference: https://github.com/yarnpkg/yarn/issues/4379

For an explanation of exactly what --frozen-lockfile or --pure-lockfile do, see [this](https://github.com/yarnpkg/yarn/issues/5847#issuecomment-537521943)