### PR TITLE
fix: collect selected epoch payment

### DIFF
--- a/apps/dapp/src/components/Pages/TeamPayments.tsx
+++ b/apps/dapp/src/components/Pages/TeamPayments.tsx
@@ -227,7 +227,6 @@ function useTempleTeamPayments(): TeamPaymentsState {
     dispatch({ type: 'collect-fixed' });
 
     const tx = await collectTempleTeamPayment(
-      TEAM_PAYMENTS_TYPES.FIXED,
       selectedEpoch
     );
 


### PR DESCRIPTION
# Description
This PR fixes a bug that was introduced as part of #123 . An enum was deleted and a function body that referenced it was not updated to use the correct `selectedEpoch`. 

Fixes #127 
Fixes a bug where we were calling `collectTempleTeamPayment` with the wrong arguments.  There was a type error that was causing builds to fail

# Checklist
- [x] Code follows the style guide
- [x] I have performed a self-review of my own code
- [x] New and existing tests pass locally
- [x] This PR is targeting the correct branch 