### PR TITLE
feat: Push stage and prod deploy status to discord

### DIFF
--- a/.github/workflows/dapp-prod.yaml
+++ b/.github/workflows/dapp-prod.yaml
@@ -13,6 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: amondnet/vercel-action@v20
+        id: deploy_step
         with:
           vercel-token: ${{ secrets.VERCEL_TOKEN }} # Required
           vercel-args: '--prod -A apps/dapp/vercel.json' #Optional
@@ -23,3 +24,22 @@ jobs:
           scope: ${{ secrets.VERCEL_ORG_ID }}
           alias-domains: | #Optional
             templedao.link
+          continue-on-error: true
+      - name: "notify failure"
+        if: steps.deploy_step.outcome == 'failure'
+        uses: rjstone/discord-webhook-notify@v1
+        with:
+          severity: error
+          description: PROD Deploy to Vercel failed!
+          details: Check the GH Action or Vercel logs for details.
+          webhookUrl: ${{ secrets.DISCORD_WEBHOOK_URL }}
+      - name: "fail"
+        if: steps.deploy_step.outcome == 'failure'
+        run: exit 1
+      - name: "notify success"
+        uses: rjstone/discord-webhook-notify@v1
+        with:
+          severity: info
+          description: PROD Deploy to Vercel succeeded!
+          details: "[View Prod Deployment](https://templedao.link)"
+          webhookUrl: ${{ secrets.DISCORD_WEBHOOK_URL }}

--- a/.github/workflows/dapp-stage.yaml
+++ b/.github/workflows/dapp-stage.yaml
@@ -12,6 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: amondnet/vercel-action@v20
+        id: deploy_step 
         with:
           vercel-token: ${{ secrets.VERCEL_TOKEN }} # Required
           vercel-args: '-A apps/dapp/vercel.json' #Optional
@@ -22,3 +23,22 @@ jobs:
           scope: ${{ secrets.VERCEL_ORG_ID }}
           alias-domains: | #Optional
             stage.templedao.link
+          continue-on-error: true
+      - name: "notify failure"
+        if: steps.deploy_step.outcome == 'failure'
+        uses: rjstone/discord-webhook-notify@v1
+        with:
+          severity: error
+          description: STAGE Deploy to Vercel failed!
+          details: Check the GH Action or Vercel logs for details.
+          webhookUrl: ${{ secrets.DISCORD_WEBHOOK_URL }}
+      - name: "fail"
+        if: steps.deploy_step.outcome == 'failure'
+        run: exit 1
+      - name: "notify success"
+        uses: rjstone/discord-webhook-notify@v1
+        with:
+          severity: info
+          description: STAGE Deploy to Vercel succeeded!
+          details: "[View Stage Deployment](https://stage.templedao.link)"
+          webhookUrl: ${{ secrets.DISCORD_WEBHOOK_URL }}


### PR DESCRIPTION
# Description

This PR updates existing dapp-stage and prod deploy workflows to output the status to Discord (a message in #dev-ops-chamber).

# Checklist
- [x] Code follows the style guide
- [x] I have performed a self-review of my own code
- [x] New and existing tests pass locally
- [x] This PR is targeting the correct branch 