### PR TITLE
fix(dapp): reduce number of requests in Withdraw.tsx

### DIFF
--- a/apps/dapp/src/components/AMM/Withdraw.tsx
+++ b/apps/dapp/src/components/AMM/Withdraw.tsx
@@ -17,7 +17,6 @@ import {
   ViewContainer,
 } from 'components/AMM/helpers/components';
 
-
 interface SizeProps {
   small?: boolean;
 }
@@ -25,7 +24,7 @@ interface SizeProps {
 export const Withdraw: FC<SizeProps> = ({ small }) => {
   const {
     exitQueueData,
-    updateWallet,
+    getExitQueueData,
     restakeAvailableTemple,
     claimAvailableTemple,
   } = useWallet();
@@ -34,7 +33,7 @@ export const Withdraw: FC<SizeProps> = ({ small }) => {
 
   useEffect(() => {
     async function onMount() {
-      await updateWallet();
+      await getExitQueueData();
     }
 
     onMount();
@@ -107,23 +106,23 @@ export const Withdraw: FC<SizeProps> = ({ small }) => {
       </Flex>
       <Spacer small />
       <ButtonContainer layout={{ kind: 'container' }}>
-          <Button
-            isSmall={small}
-            label={'restake pending $TEMPLE'}
-            onClick={restakeAvailableTemple}
-            isUppercase
-            disabled={
-              exitQueueData.totalTempleOwned === 0 &&
-              exitQueueData.claimableTemple === 0
-            }
-          />
-          <Button
-            isSmall={small}
-            label={'withdraw available $TEMPLE'}
-            onClick={claimAvailableTemple}
-            isUppercase
-            disabled={exitQueueData.claimableTemple == 0}
-          />
+        <Button
+          isSmall={small}
+          label={'restake pending $TEMPLE'}
+          onClick={restakeAvailableTemple}
+          isUppercase
+          disabled={
+            exitQueueData.totalTempleOwned === 0 &&
+            exitQueueData.claimableTemple === 0
+          }
+        />
+        <Button
+          isSmall={small}
+          label={'withdraw available $TEMPLE'}
+          onClick={claimAvailableTemple}
+          isUppercase
+          disabled={exitQueueData.claimableTemple == 0}
+        />
       </ButtonContainer>
     </ViewContainer>
   );

--- a/apps/dapp/src/providers/WalletProvider.tsx
+++ b/apps/dapp/src/providers/WalletProvider.tsx
@@ -248,6 +248,8 @@ interface WalletState {
   getTempleFaithReward(faithAmount: BigNumber): Promise<BigNumber | void>;
 
   getFaithQuote(): Promise<FaithQuote | void>;
+
+  getExitQueueData(): Promise<ExitQueueData | void>;
 }
 
 const INITIAL_STATE: WalletState = {
@@ -325,6 +327,7 @@ const INITIAL_STATE: WalletState = {
   redeemFaith: asyncNoop,
   getTempleFaithReward: asyncNoop,
   getFaithQuote: asyncNoop,
+  getExitQueueData: asyncNoop,
 };
 
 const STABLE_COIN_ADDRESS = ENV_VARS.VITE_PUBLIC_STABLE_COIN_ADDRESS;
@@ -1877,6 +1880,7 @@ export const WalletProvider = (props: PropsWithChildren<any>) => {
         getTempleFaithReward,
         getFaithQuote,
         faith,
+        getExitQueueData,
       }}
     >
       {children}


### PR DESCRIPTION
# Description
Cuts down on unnecessary requests performed by `Withdraw.tsx` on mount which is causing some users to not be able to claim their $TEMPLE.

See https://github.com/TempleDAO/temple/issues/132

Fixes #132

# Checklist
- [x] Code follows the style guide
- [x] I have performed a self-review of my own code
- [x] New and existing tests pass locally
- [x] This PR is targeting the correct branch 