### PR TITLE
fix(dapp): update temple price for AMM screens

### DIFF
--- a/apps/dapp/src/components/AMM/Buy.tsx
+++ b/apps/dapp/src/components/AMM/Buy.tsx
@@ -27,7 +27,7 @@ const ENV_VARS = import.meta.env;
 
 export const Buy: FC<BuyProps> = ({ onSwapArrowClick, small }) => {
   const { balance, getBalance, updateBalance } = useWallet();
-  const { buy, getBuyQuote, templePrice } = useSwap();
+  const { buy, getBuyQuote, templePrice, updateTemplePrice } = useSwap();
 
   const [stableCoinAmount, setStableCoinAmount] = useState<number | ''>('');
   const [stableCoinWalletAmount, setStableCoinWalletAmount] =
@@ -41,9 +41,6 @@ export const Buy: FC<BuyProps> = ({ onSwapArrowClick, small }) => {
     setStableCoinAmount(value === 0 ? '' : value);
     if (value) {
       setRewards(
-        fromAtto((await getBuyQuote(toAtto(value))) || BigNumber.from(0) || 0)
-      );
-      console.log(
         fromAtto((await getBuyQuote(toAtto(value))) || BigNumber.from(0) || 0)
       );
     } else {
@@ -60,10 +57,6 @@ export const Buy: FC<BuyProps> = ({ onSwapArrowClick, small }) => {
       if (stableCoinAmount) {
         const minAmountOut =
           (stableCoinAmount / templePrice) * (1 - slippage / 100);
-        console.log('CALCULATING');
-        console.log('stableCoinAmount', stableCoinAmount);
-        console.log('templePrice', templePrice);
-        console.log('slippage', slippage);
         setMinAmountOut(minAmountOut);
         if (minAmountOut <= rewards) {
           await buy(toAtto(stableCoinAmount), toAtto(minAmountOut));
@@ -86,15 +79,13 @@ export const Buy: FC<BuyProps> = ({ onSwapArrowClick, small }) => {
   useEffect(() => {
     async function onMount() {
       await updateBalance();
+      await updateTemplePrice();
       setRewards('');
       setMinAmountOut(0);
     }
 
     onMount();
   }, []);
-
-  console.log('minAmountOut', minAmountOut);
-  console.log('rewards', rewards);
 
   return (
     <ViewContainer>

--- a/apps/dapp/src/components/AMM/Sell.tsx
+++ b/apps/dapp/src/components/AMM/Sell.tsx
@@ -29,7 +29,8 @@ const ENV_VARS = import.meta.env;
 
 export const Sell: FC<BuyProps> = ({ onSwapArrowClick, small }) => {
   const { balance, getBalance, updateBalance } = useWallet();
-  const { sell, getSellQuote, templePrice, iv, updateIv } = useSwap();
+  const { sell, getSellQuote, templePrice, updateTemplePrice, iv, updateIv } =
+    useSwap();
 
   const [stableCoinWalletAmount, setStableCoinWalletAmount] =
     useState<number>(0);
@@ -86,6 +87,7 @@ export const Sell: FC<BuyProps> = ({ onSwapArrowClick, small }) => {
   useEffect(() => {
     async function onMount() {
       await updateBalance();
+      await updateTemplePrice();
       await updateIv();
       setRewards('');
       setMinAmountOut(0);

--- a/apps/dapp/src/components/Pages/DAppRoot.tsx
+++ b/apps/dapp/src/components/Pages/DAppRoot.tsx
@@ -1,6 +1,7 @@
-import React, { FC, useState } from 'react';
+import React, { FC, useState, useEffect } from 'react';
 import { useMediaQuery } from 'react-responsive';
 import styled from 'styled-components';
+import { useRefreshWalletState } from 'hooks/use-refresh-wallet-state';
 import MetamaskButton from 'components/Button/MetamaskButton';
 import DevotionCTA from 'components/Accessories/DevotionCTA';
 import { DApp } from 'components/DApp/DApp';
@@ -17,6 +18,11 @@ const DAppRoot = () => {
   const isSmallOrMediumScreen = useMediaQuery({ query: '(max-width: 800px)' });
   const [activeView, setView] = useState(DAppView.BUY);
   const navContext = { activeView, setView };
+  const refreshWalletState = useRefreshWalletState();
+
+  useEffect(() => {
+    refreshWalletState();
+  }, []);
 
   return (
     <NavContext.Provider value={navContext}>


### PR DESCRIPTION
# Description
Users were not able to buy $TEMPLE through the UI due to `templePrice` not being initialized which led to calculations resulting in `Infinity`.

This PR makes it so the entire wallet state is updated when the AMM is first visited as well as updating the `templePrice` on load for the buy and sell pages.

# Checklist
- [x] Code follows the style guide
- [x] I have performed a self-review of my own code
- [x] New and existing tests pass locally
- [x] This PR is targeting the correct branch 