### PR TITLE
Chore: add chainId 1337 to Hardhat config

### DIFF
--- a/apps/protocol/hardhat.config.ts
+++ b/apps/protocol/hardhat.config.ts
@@ -59,6 +59,9 @@ module.exports = {
     outDir: './typechain',
   },
   networks: {
+    hardhat: {
+      chainId: 1337,
+    },
     rinkeby: {
       url: process.env.RINKEBY_RPC_URL || '',
       accounts: process.env.RINKEBY_ADDRESS_PRIVATE_KEY


### PR DESCRIPTION
# Description
Sets 1337 as the default chainId when on Hardhat network
1337 is the chainId Hardhat needs to use to interact with Metamask - we should add it in our config so devs don't have to manually.

# Checklist
- [x] Code follows the style guide
- [x] I have performed a self-review of my own code
- [x] New and existing tests pass locally
- [x] This PR is targeting the correct branch 