### PR TITLE
CORE: fix: update Tab styling to work with new buttons

### DIFF
--- a/apps/dapp/src/components/Tabs/Tabs.tsx
+++ b/apps/dapp/src/components/Tabs/Tabs.tsx
@@ -87,8 +87,11 @@ interface TabStyledProps {
 
 const TabStyled = styled(Button)<TabStyledProps>`
   flex: 1;
+  border-radius: 0;
+  background: transparent;
+  color: ${(props) => props.theme.palette.brand};
   text-transform: none;
-  height: 2rem;
+  height: 2.25rem;
   max-width: max-content;
   border: ${pixelsToRems(1)}rem solid transparent;
   ${(props) =>


### PR DESCRIPTION
# Description
The updated Button component was overriding some stying in the Tabs component as the tabs are extended Buttons
This fix specifies no border radius, transparent background and font colour so the tabs appear as intended

![image](https://user-images.githubusercontent.com/96315255/159551268-8a380aa1-83f1-4882-a4dd-9c2146f98f96.png)

# Checklist
- [ ] Code follows the style guide
- [ ] I have performed a self-review of my own code
- [ ] New and existing tests pass locally
- [ ] This PR is targeting the correct branch 