### PR TITLE
CORE: Core nav updates

### DIFF
--- a/apps/dapp/src/components/Layouts/CoreLayout/Header.tsx
+++ b/apps/dapp/src/components/Layouts/CoreLayout/Header.tsx
@@ -87,28 +87,28 @@ const Navigation = ({ isNavOpenMobile, onClickMenuItem }: NavigationProps) => {
           Home
         </MenuItem>
         <MenuItem
-          to="/core/vaults"
+          to="/core/dapp/vaults"
           onMenuItemActive={onMenuItemActive}
           onClick={onClickMenuItem}
         >
           Vaults
         </MenuItem>
         <MenuItem
-          to="/core/trade"
+          to="/core/dapp/trade"
           onMenuItemActive={onMenuItemActive}
           onClick={onClickMenuItem}
         >
           Trade
         </MenuItem>
         <MenuItem
-          to="/core/profile"
+          to="/core/dapp/profile"
           onMenuItemActive={onMenuItemActive}
           onClick={onClickMenuItem}
         >
           Profile
         </MenuItem>
         <MenuItem
-          to="/core/analytics"
+          to="/core/dapp/analytics"
           onMenuItemActive={onMenuItemActive}
           onClick={onClickMenuItem}
         >

--- a/apps/dapp/src/components/Pages/Core/Profile/components/ProfileVaults.tsx
+++ b/apps/dapp/src/components/Pages/Core/Profile/components/ProfileVaults.tsx
@@ -24,7 +24,7 @@ export const ProfileVaults: React.FC<IProps> = ({ isLoading, vaults }) => {
   if (!vaults.length) {
     return (
       <Container>
-        <Button isSmall as="a" label="Enter a vault" href="/core/vaults" />
+        <Button isSmall as="a" label="Enter a vault" href="/core/dapp/vaults" />
       </Container>
     );
   }

--- a/apps/dapp/src/components/Pages/Core/VaultList.tsx
+++ b/apps/dapp/src/components/Pages/Core/VaultList.tsx
@@ -3,7 +3,7 @@ import { Navigate } from 'react-router-dom';
 
 import Loader from 'components/Loader/Loader';
 
-const data = ['abc']
+const data = ['abc'];
 
 const useMockVaultData = () => {
   const [isLoading, setIsLoading] = useState(true);
@@ -29,7 +29,7 @@ const VaultListPage = () => {
   }
 
   if (data.length === 1) {
-    return <Navigate replace to={`/core/vaults/${data[0]}/summary`} />;
+    return <Navigate replace to={`/core/dapp/vaults/${data[0]}/summary`} />;
   }
 
   return <div>Vault List View</div>;

--- a/apps/dapp/src/components/Vault/VaultSVG.tsx
+++ b/apps/dapp/src/components/Vault/VaultSVG.tsx
@@ -20,7 +20,13 @@ type Props = {
   data: Vault;
 };
 
-const VAULT_PAGES: VaultPage[] = ['claim', 'stake', 'summary', 'strategy', 'timing'];
+const VAULT_PAGES: VaultPage[] = [
+  'claim',
+  'stake',
+  'summary',
+  'strategy',
+  'timing',
+];
 
 const useSelectedVaultPage = (): Maybe<VaultPage> => {
   const { pathname } = useLocation();
@@ -75,7 +81,7 @@ export const VaultSVG = ({ data, children }: PropsWithChildren<Props>) => {
           <RingButtons
             selected={selectedNav}
             onClickButton={(page) => {
-              navigate(`/core/vaults/${data.id}/${page}`);
+              navigate(`/core/dapp/vaults/${data.id}/${page}`);
             }}
           />
           <Timeline data={vault} onMarkerClick={markerClick} />

--- a/apps/dapp/src/main.tsx
+++ b/apps/dapp/src/main.tsx
@@ -69,17 +69,17 @@ ReactDOM.render(
           <>
             <Route path="/core/*" element={<CoreLayout />}>
               <Route path="" element={'Home'} />
-              <Route path="vaults" element={<VaultListPage />} />
-              <Route path="vaults/:vaultId/*" element={<VaultPage />}>
-                <Route path="claim" element={<VaultClaim />} />
-                <Route path="stake" element={<Stake />} />
-                <Route path="summary" element={<Summary />} />
-                <Route path="strategy" element={<Strategy />} />
-                <Route path="timing" element={<Timing />} />
+              <Route path="dapp/vaults" element={<VaultListPage />} />
+              <Route path="dapp/vaults/:vaultId/*" element={<VaultPage />}>
+                <Route path="dapp/claim" element={<VaultClaim />} />
+                <Route path="dapp/stake" element={<Stake />} />
+                <Route path="dapp/summary" element={<Summary />} />
+                <Route path="dapp/strategy" element={<Strategy />} />
+                <Route path="dapp/timing" element={<Timing />} />
               </Route>
-              <Route path="trade" element={'Trade'} />
-              <Route path="profile" element={<ProfilePage />} />
-              <Route path="analytics" element={<AnalyticsPage />} />
+              <Route path="dapp/trade" element={'Trade'} />
+              <Route path="dapp/profile" element={<ProfilePage />} />
+              <Route path="dapp/analytics" element={<AnalyticsPage />} />
               {/* Redirect everything else to the home page */}
               <Route path="*" element={<Navigate replace to="/" />} />
             </Route>


### PR DESCRIPTION
# Description

Restructures the core URL routes, placing everything under the `/core/dapp/` path, except the landing page `/core/`. 

Fixes https://www.notion.so/templedao/Restructure-URL-Routes-5adf2fdf11ed4ed1b8785a095f1c5f9f

# Checklist
- [x] Code follows the style guide
- [x] I have performed a self-review of my own code
- [x] New and existing tests pass locally
- [x] This PR is targeting the correct branch 