### PR TITLE
Min changes to router so there is no arb with an IV Swap

### DIFF
--- a/apps/protocol/contracts/amm/TempleFraxAMMRouter.sol
+++ b/apps/protocol/contracts/amm/TempleFraxAMMRouter.sol
@@ -409,14 +409,18 @@ contract TempleFraxAMMRouter is Ownable, AccessControl {
         (uint256 ivFrax, uint256 ivTemple) = templeTreasury.intrinsicValueRatio();
         priceBelowIV = ivTemple * reserveFrax <= reserveTemple * ivFrax;
 
-        if (priceBelowIV) {
-            amountOut = (amountIn * ivFrax) / ivTemple;
+        uint256 amountOutAmm = getAmountOut(amountIn, reserveTemple, reserveFrax);
+        uint256 amountOutIvSwap = (amountIn * ivFrax) / ivTemple;
+
+        if (amountOutIvSwap > amountOutAmm) {
+            amountOut = amountOutIvSwap;
+            priceBelowIV = true;
         } else {
-            amountOut = getAmountOut(amountIn, reserveTemple, reserveFrax);
+            amountOut = amountOutAmm;
+            priceBelowIV = false;
         }
 
         // Will this sell move the price from above to below the dynamic threshold?
-
         if (!priceBelowIV) {
             (uint thresholdPriceFrax, uint thresholdPriceTemple) = dynamicThresholdPriceWithDecay();
 


### PR DESCRIPTION
# Description
The current defend implementation opens up an opportunity for external arbitragers namely
   1. Price is just above IV, the sell will be routed to the AMM
   2. Price is now below IV, arb bot comes in and snipes the price back up a bit.

Fix is to change the contract s.t the user always gets the best price as part of the protocol.

This is a draft PR - someone on the team needs to take this, implement tests etc to bring it home. It shows the minimal seam in which we can achieve this goal

# Checklist
- [ ] Code follows the style guide
- [ ] I have performed a self-review of my own code
- [ ] New and existing tests pass locally
- [ ] This PR is targeting the correct branch 