### PR TITLE
Add bounds to the vault fuzz tests

### DIFF
--- a/protocol/contracts/test/Vault.t.sol
+++ b/protocol/contracts/test/Vault.t.sol
@@ -109,6 +109,9 @@ contract VaultTest is TempleTest {
 
     // This shouldn't fail? 
     function testFuzzWithdrawFor(uint256 amount) public {
+        // bound the fuzzing input - I doubt we'll ever hit someone depositing 366 trillion temple
+        vm.assume(amount < 340282366920938463463374607431768211455);
+        
         // build user
         uint256 priv = 0xBEEF;
         address sally = vm.addr(priv);
@@ -143,6 +146,9 @@ contract VaultTest is TempleTest {
     }
 
     function testFuzzDepositFor(uint256 amount) public {
+        // bound the fuzzing input - I doubt we'll ever hit someone depositing 366 trillion temple
+        vm.assume(amount < 340282366920938463463374607431768211455);
+
         // build user
         uint256 priv = 0xBEEF;
         address sally = vm.addr(priv);
@@ -174,6 +180,9 @@ contract VaultTest is TempleTest {
     }
 
     function testFuzzDepositWithdraw(uint256 amount) public {
+        // bound the fuzzing input - I doubt we'll ever hit someone depositing 366 trillion temple
+        vm.assume(amount < 340282366920938463463374607431768211455);
+        
         // mint
         temple.mint(alice, amount);
 
@@ -183,7 +192,6 @@ contract VaultTest is TempleTest {
         vault.deposit(amount);
 
         vm.warp(160 + (60*4));
-        // Current fails due to arithmetic overflow
         vault.withdraw(amount);
         vm.stopPrank();
 


### PR DESCRIPTION
# Description
Fixes some "failing" tests with the RebasineERC20.sol contract. Was attempting to deposit and withdraw 366 trillion temple tokens, which is not a number we should hit. 

Fixes https://github.com/TempleDAO/temple/pull/156#discussion_r853648587

# Checklist
- [x] Code follows the style guide
- [x] I have performed a self-review of my own code
- [x] New and existing tests pass locally
- [x] This PR is targeting the correct branch 