### PR TITLE
Remove stale data when graph-node is started

### DIFF
--- a/apps/core-subgraph/package.json
+++ b/apps/core-subgraph/package.json
@@ -9,7 +9,7 @@
     "remove-local": "graph remove --node http://localhost:8020/ templedao-core",
     "deploy-local": "graph deploy --node http://localhost:8020/ --ipfs http://localhost:5001 templedao-core",
     "graph:setup": "./scripts/graph-node-setup.sh",
-    "graph:start": "cd graph-node/docker && docker compose up",
+    "graph:start": "rm -rf graph-node/docker/data && cd graph-node/docker && docker compose up",
     "graph:stop": "cd graph-node/docker && docker compose down"
   },
   "dependencies": {


### PR DESCRIPTION
# Description

Dariox mentioned we should do this when we start the graph-node or else we're stuck with stale/bad data.

Fixes # (issue)

# Checklist
- [ ] Code follows the style guide
- [ ] I have performed a self-review of my own code
- [ ] New and existing tests pass locally
- [ ] This PR is targeting the correct branch 