### PR TITLE
Add Identifier to the Vault contract

### DIFF
--- a/protocol/contracts/core/OpsManager.sol
+++ b/protocol/contracts/core/OpsManager.sol
@@ -50,11 +50,12 @@ contract OpsManager is Ownable {
     function createVault(
         string memory name,
         string memory symbol,
+        string memory identifier,
         uint256 periodDuration,
         uint256 enterExitWindowDuration,
         Rational memory shareBoostFactory
     ) external onlyOwner {
-        Vault vault = new Vault(name, symbol, templeToken, periodDuration, enterExitWindowDuration, shareBoostFactory, joiningFee);
+        Vault vault = new Vault(name, symbol, identifier, templeToken, periodDuration, enterExitWindowDuration, shareBoostFactory, joiningFee);
         activeVaults[address(vault)] = true;
         emit CreateVault(address(vault));
     }

--- a/protocol/contracts/core/Vault.sol
+++ b/protocol/contracts/core/Vault.sol
@@ -54,15 +54,20 @@ contract Vault is EIP712, Ownable, RebasingERC20 {
     /// @dev Where to query the fee (per hour) when joining the vault
     JoiningFee public joiningFee;
 
+    /// @dev Grouping Identifier to allow downstream to group together vault instances into a single logical vault
+    string public identifier;
+
     constructor(
         string memory _name,
         string memory _symbol,
+        string memory _identifier,
         IERC20 _templeToken,
         uint256 _periodDuration,
         uint256 _enterExitWindowDuration,
         Rational memory _shareBoostFactory,
         JoiningFee _joiningFee
     ) EIP712(_name, "1") ERC20(_name, _symbol)  {
+        identifier = _identifier;
         templeToken = _templeToken;
         periodDuration = _periodDuration;
         enterExitWindowDuration = _enterExitWindowDuration;

--- a/protocol/contracts/test/Vault.t.sol
+++ b/protocol/contracts/test/Vault.t.sol
@@ -33,6 +33,7 @@ contract VaultTest is TempleTest {
         vault = new Vault(
             "Temple 5 Min Vault",
             "T5MV",
+            "TV_EXAMPLE_5M",
             temple,
             FIVE_MIN_DURATION,
             60,

--- a/protocol/scripts/local-dapp-dev/deploy.ts
+++ b/protocol/scripts/local-dapp-dev/deploy.ts
@@ -277,6 +277,7 @@ async function main() {
   const vaultTx = await opsManager.createVault(
     "Temple 1 Month Vault",
     "TV_1MO",
+    "TV_EXAMPLE_1M",
     60 * 60 * 24 * 30, //30 days
     60 * 60 * 24, // 1 day
     { p: 1, q : 1}

--- a/protocol/test/core/vault-tests.ts
+++ b/protocol/test/core/vault-tests.ts
@@ -36,6 +36,7 @@ describe("Temple Core Vault", async () => {
     vault = await new Vault__factory(owner).deploy(
         "Temple 1m Vault",
         "TV_1M",
+        "TV_EXAMPLE_1M",
         templeToken.address,
         60 * 5,
         60,


### PR DESCRIPTION
# Description
Adds Identifier to the vault constructor to allow downstream apps to group together vault instances

# Checklist
- [x] Code follows the style guide
- [x] I have performed a self-review of my own code
- [x] New and existing tests pass locally
- [x] This PR is targeting the correct branch 