### PR TITLE
Use subgraph for homepage metrics

### DIFF
--- a/apps/dapp/src/hooks/use-refreshable-treasury-metrics.tsx
+++ b/apps/dapp/src/hooks/use-refreshable-treasury-metrics.tsx
@@ -33,8 +33,12 @@ export default function useRefreshableTreasuryMetrics() {
   }
 
   async function refreshMetrics() {
-    const treasuryMetrics = await getTreasuryMetrics();
-    setTreasuryMetrics(treasuryMetrics);
+    try {
+      const treasuryMetrics = await getTreasuryMetrics();
+      setTreasuryMetrics(treasuryMetrics);
+    } catch (error) {
+      console.info(error);
+    }
   }
 
   const clearInterval = useInterval(refreshMetrics, 5 * 60 * 1000, true);

--- a/apps/dapp/src/utils/subgraph.ts
+++ b/apps/dapp/src/utils/subgraph.ts
@@ -1,3 +1,10 @@
+export class SubgraphQueryError extends Error {
+  constructor(graphqlErrors: any[]) {
+    super(graphqlErrors.map((errorPath) => errorPath.message).join(';'));
+    this.name = 'SubgraphQueryError';
+  }
+}
+
 export const fetchSubgraph = async (query: string) => {
   const result = await fetch(
     'https://api.thegraph.com/subgraphs/name/templedao/templedao-metrics',
@@ -13,5 +20,9 @@ export const fetchSubgraph = async (query: string) => {
     }
   );
   const response = await result.json();
+
+  if (response.errors) {
+    throw new SubgraphQueryError(response.errors);
+  }
   return response;
 };


### PR DESCRIPTION
# Description

Instead of relying on contract queries, we pull the homepage metrics from the subgraph.

To test it, you can go to the preview link in a private window or browser that does not have metamask and see the metrics work fine.

If approved, we can port this fix into `core` as well.

<img width="476" alt="Screen Shot 2022-05-03 at 9 24 11 AM" src="https://user-images.githubusercontent.com/99344331/166465515-4df2d6bf-9909-4aaa-80ee-ca3fe6c390ec.png">


Fixes # (issue)

# Checklist
- [ ] Code follows the style guide
- [ ] I have performed a self-review of my own code
- [ ] New and existing tests pass locally
- [ ] This PR is targeting the correct branch 