### PR TITLE
Introduce failing faith precision tests

### DIFF
--- a/protocol/test/core/vault-proxy-tests.ts
+++ b/protocol/test/core/vault-proxy-tests.ts
@@ -1,5 +1,5 @@
 import { ethers } from "hardhat";
-import { blockTimestamp, deployAndAirdropTemple, mineForwardSeconds, toAtto } from "../helpers";
+import { blockTimestamp, deployAndAirdropTemple, fromAtto, mineForwardSeconds, toAtto } from "../helpers";
 import { Signer } from "ethers";
 import {
     AcceleratedExitQueue,
@@ -144,7 +144,7 @@ describe.only("Vault Proxy", async () => {
   const faithData = [
     {temple: 7000, faith: 5000, expected: 9000},
     {temple: 2345, faith: 10000, expected: 3048.5},
-    {temple: 2345, faith: 100, expected: 2385.4},
+    {temple: 2345, faith: 100, expected: 2385},
     {temple: 100, faith: 2345, expected: 130}
   ];
 
@@ -156,7 +156,7 @@ describe.only("Vault Proxy", async () => {
       await TEMPLE.connect(alan).increaseAllowance(VAULT_PROXY.address, toAtto(10000))
       await VAULT_PROXY.connect(alan).depositTempleWithFaith(toAtto(data.temple), toAtto(data.faith), vault.address);
 
-      expect(await vault.balanceOf(await alan.getAddress())).equals(toAtto(data.expected));
+      expect(fromAtto(await vault.balanceOf(await alan.getAddress()))).approximately(data.expected, 1e-6);
     })
   })
 


### PR DESCRIPTION
# Description
We currently have a precision issue when determining how much Temple faith should boost by. For instance, given 7000 Temple and 5000 Faith, this should produce a deposit of 9000 Temple (a boost of 2000 Temple) - however, the contract instead will return a boost of 1999.999999999 Temple.

This PR introduces some fail unit tests for us to resolve. 

# Checklist
- [ ] Code follows the style guide
- [ ] I have performed a self-review of my own code
- [ ] New and existing tests pass locally
- [ ] This PR is targeting the correct branch 