### PR TITLE
Fix OGT Staking APY

### DIFF
--- a/apps/dapp/src/hooks/use-refreshable-treasury-metrics.tsx
+++ b/apps/dapp/src/hooks/use-refreshable-treasury-metrics.tsx
@@ -21,7 +21,7 @@ export default function useRefreshableTreasuryMetrics() {
     const data = response?.data?.protocolMetrics?.[0] || {};
 
     const epy = parseFloat(data.epochPercentageYield);
-    const templeApy = Math.trunc((Math.pow(epy + 1, 365.25) - 1) * 100);
+    const templeApy = Math.round((Math.pow(epy + 1, 365.25) - 1) * 100);
     const templePrice = parseFloat(data.templePrice);
     const lockedStables = parseFloat(data.lockedStables);
 


### PR DESCRIPTION
# Description
We were using Math.trunc which showed 9% APY when in reality the calculation would come out closer to ~ 9.996, meaning we're effectively losing an entire % in the shown APY.

Fixes # (issue)

# Checklist
- [x] Code follows the style guide
- [x] I have performed a self-review of my own code
- [x] New and existing tests pass locally
- [x] This PR is targeting the correct branch 