### PR TITLE
Add proxy functions for Exposures in OpsManager

### DIFF
--- a/protocol/contracts/core/OpsManager.sol
+++ b/protocol/contracts/core/OpsManager.sol
@@ -169,6 +169,22 @@ contract OpsManager is Ownable {
         return OpsManagerLib.requiresRebalance(vaults, pools[exposureToken]);
     }
 
+    /**
+        Proxy function to set a liquidator for a given exposure; needed as OpsManager is the owner of all exposures created
+        with the OpsManager.
+     */
+    function setExposureLiquidator(IERC20 exposureToken, ILiquidator _liquidator) external onlyOwner {
+        OpsManagerLib.setExposureLiquidator(pools, exposureToken, _liquidator);
+    }
+
+    /**
+        Proxy function to set minter state for a given exposure; needed as OpsManager is the owner of all exposures created
+        with the OpsManager.
+     */
+    function setExposureMinterState(IERC20 exposureToken, address account, bool state) external onlyOwner {
+        OpsManagerLib.setExposureMinterState(pools, exposureToken, account, state);
+    }
+
     event CreateVaultInstance(address vault);
     event CreateExposure(address exposure, address primaryRevenue);
 }

--- a/protocol/contracts/core/OpsManagerLib.sol
+++ b/protocol/contracts/core/OpsManagerLib.sol
@@ -22,11 +22,34 @@ library OpsManagerLib {
         pools[revalToken] = new TreasuryFarmingRevenue(exposure);
         exposure.setMinterState(address(pools[revalToken]), true);
 
-        // transfer exposure ownership back to ops manager, as it manages
-        // exposure rebasing
-        exposure.transferOwnership(msg.sender);
-
         return exposure;
+    }
+
+    /**
+        Proxy function to set a liquidator for a given exposure; needed as OpsManager is the owner of all exposures created
+        with the OpsManager.
+     */
+    function setExposureLiquidator(
+        mapping(IERC20 => TreasuryFarmingRevenue) storage pools, 
+        IERC20 exposureToken, 
+        ILiquidator _liquidator
+    ) public {
+        Exposure exposure = pools[exposureToken].exposure();
+        exposure.setLiqidator(_liquidator);
+    }
+
+    /**
+        Proxy function to set minter state for a given exposure; needed as OpsManager is the owner of all exposures created
+        with the OpsManager.
+     */
+    function setExposureMinterState(
+        mapping(IERC20 => TreasuryFarmingRevenue) storage pools, 
+        IERC20 exposureToken, 
+        address account, 
+        bool state
+    ) public {
+        Exposure exposure = pools[exposureToken].exposure();
+        exposure.setMinterState(account, state);
     }
 
     function rebalance(


### PR DESCRIPTION
# Description
Sets Exposures created using OpsManager to be owned by the OpsManager. Creates passthrough/proxy functions which allow the OpsManager owner to call privileged functions within an Exposure. 

# Checklist
- [x] Code follows the style guide
- [x] I have performed a self-review of my own code
- [x] New and existing tests pass locally
- [x] This PR is targeting the correct branch 