### PR TITLE
Update homepage to use vAPY

### DIFF
--- a/apps/dapp/src/components/Metrics/Metrics.tsx
+++ b/apps/dapp/src/components/Metrics/Metrics.tsx
@@ -17,7 +17,7 @@ export interface MetricsProps {
 }
 
 const Metrics = ({ treasuryMetrics, isHome, alignCenter, }: MetricsProps) => {
-  const { treasuryValue, templeApy, templeValue } = treasuryMetrics;
+  const { treasuryValue, templeValue } = treasuryMetrics;
 
   return (
     <Wrapper>
@@ -35,8 +35,8 @@ const Metrics = ({ treasuryMetrics, isHome, alignCenter, }: MetricsProps) => {
       </ApyWrapper>
       <ApyWrapper>
         <Apy
-          cryptoName={'APY'}
-          value={`${formatNumber(templeApy)}%`}
+          cryptoName={'vAPY'}
+          value={`${formatNumber(9)}%`}
           imageData={{
             imageUrl: tagImage,
             alt: '',


### PR DESCRIPTION
# Description
Updates homepage to use vAPY for Vaults, rather than OGT APY.

![localhost_3000_ (2)](https://user-images.githubusercontent.com/92979684/174996974-b13b24d9-6392-4123-a85f-85418a20d092.png)

# Checklist
- [x] Code follows the style guide
- [x] I have performed a self-review of my own code
- [x] New and existing tests pass locally
- [x] This PR is targeting the correct branch 