### PR TITLE
Change INITIAL_STATE of isFraxSellDisabled from true to false

### DIFF
--- a/apps/dapp/src/components/Pages/Core/Trade/constants.ts
+++ b/apps/dapp/src/components/Pages/Core/Trade/constants.ts
@@ -29,7 +29,7 @@ export const INITIAL_STATE: SwapReducerState = {
   buttonLabel: createButtonLabel(TICKER_SYMBOL.FRAX, TICKER_SYMBOL.TEMPLE_TOKEN, SwapMode.Buy),
   isTransactionPending: false,
   isSlippageTooHigh: false,
-  isFraxSellDisabled: true,
+  isFraxSellDisabled: false,
   error: null,
 };
 


### PR DESCRIPTION
# Description
What does this PR solve?

When first switching to selling $TEMPLE, $FRAX isn't always show as an option in the input select. This was being caused by _INITIAL_STATE_ defaulting _isFraxSellDisabled_ to false, causing the [_buildSelectConfig_ ](https://github.com/TempleDAO/temple/blob/stage/apps/dapp/src/components/Pages/Core/Trade/utils.ts#L32-L37)to render only the $FEI ticker rather than a select. 

Fixes #475 

# Checklist
- [x] Code follows the style guide
- [x] I have performed a self-review of my own code
- [x] New and existing tests pass locally
- [x] This PR is targeting the correct branch 