### PR TITLE
Add hourly snapshots for Vaults data to subgraph

### DIFF
--- a/apps/core-subgraph/schema.graphql
+++ b/apps/core-subgraph/schema.graphql
@@ -111,10 +111,10 @@ type Vault @entity {
   tvlUSD: BigDecimal!
   userCount: BigInt!
   vaultGroup: VaultGroup!
-  VaultDayDatas: [VaultDayData!]! @derivedFrom(field: "vault")
+  VaultHourDatas: [VaultHourData!]! @derivedFrom(field: "vault")
 }
 
-type VaultDayData @entity {
+type VaultHourData @entity {
   id: ID!
   timestamp: BigInt!
   tvl: BigDecimal!

--- a/apps/core-subgraph/src/entities/deposit.ts
+++ b/apps/core-subgraph/src/entities/deposit.ts
@@ -43,16 +43,14 @@ export function createDeposit(event: DepositEvent): Deposit {
   vub.token = token.id
   updateVaultUserBalance(vub, timestamp)
 
-  vault.tvl = vault.tvl.plus(staked)
-  vault.tvlUSD = vault.tvl.times(tokenPrice).plus(staked.times(tokenPrice))
+  vault.tvlUSD = vault.tvl.times(tokenPrice)
   if (oldStaked == BIG_DECIMAL_0) {
     vault.userCount = vault.userCount.plus(BIG_INT_1)
   }
   saveVault(vault, timestamp)
 
   const vaultGroup = getVaultGroup(vault.name)
-  vaultGroup.tvl = vaultGroup.tvl.plus(staked)
-  vaultGroup.tvlUSD = vaultGroup.tvl.times(tokenPrice).plus(staked.times(tokenPrice))
+  vaultGroup.tvlUSD = vaultGroup.tvl.times(tokenPrice)
   vaultGroup.volume = vaultGroup.volume.plus(amount)
   vaultGroup.volumeUSD = vaultGroup.volumeUSD.plus(amount.times(tokenPrice))
   saveVaultGroup(vaultGroup, timestamp)

--- a/apps/core-subgraph/src/entities/vault.ts
+++ b/apps/core-subgraph/src/entities/vault.ts
@@ -1,6 +1,6 @@
 import { Address, BigInt } from '@graphprotocol/graph-ts'
 
-import { Vault, VaultDayData } from '../../generated/schema'
+import { Vault, VaultHourData } from '../../generated/schema'
 import { Vault as VaultTemplate } from '../../generated/templates'
 import { CreateVaultInstance } from '../../generated/OpsManager/OpsManager'
 import { Vault as VaultContract } from '../../generated/OpsManager/Vault'
@@ -9,7 +9,7 @@ import { BIG_INT_1, BIG_DECIMAL_0 } from '../utils/constants'
 import { getMetric, updateMetric } from './metric'
 import { getOrCreateVaultGroup } from './vaultGroup'
 import { toDecimal } from '../utils/decimals'
-import { dayFromTimestamp } from '../utils/dates'
+import { hourFromTimestamp } from '../utils/dates'
 
 
 export function createVault(event: CreateVaultInstance): void {
@@ -88,23 +88,23 @@ export function saveVault(vault: Vault, timestamp: BigInt): void {
   vault.timestamp = timestamp
   vault.save()
 
-  updateOrCreateDayData(vault, timestamp)
+  updateOrCreateHourData(vault, timestamp)
 }
 
-export function updateOrCreateDayData(vault: Vault, timestamp: BigInt): void {
-  const dayTimestamp = dayFromTimestamp(timestamp);
-  const dayDataID = dayTimestamp + vault.id;
+export function updateOrCreateHourData(vault: Vault, timestamp: BigInt): void {
+  const hourTimestamp = hourFromTimestamp(timestamp);
+  const hourDataID = hourTimestamp + vault.id;
 
-  let dayData = VaultDayData.load(dayDataID)
-  if (dayData === null) {
-    dayData = new VaultDayData(dayDataID)
+  let hourData = VaultHourData.load(hourDataID)
+  if (hourData === null) {
+    hourData = new VaultHourData(hourDataID)
   }
 
-  dayData.timestamp = timestamp
-  dayData.tvl = vault.tvl
-  dayData.tvlUSD = vault.tvlUSD
-  dayData.userCount = vault.userCount
-  dayData.vault = vault.id
+  hourData.timestamp = timestamp
+  hourData.tvl = vault.tvl
+  hourData.tvlUSD = vault.tvlUSD
+  hourData.userCount = vault.userCount
+  hourData.vault = vault.id
 
-  dayData.save()
+  hourData.save()
 }

--- a/apps/core-subgraph/src/entities/withdraw.ts
+++ b/apps/core-subgraph/src/entities/withdraw.ts
@@ -41,8 +41,7 @@ export function createWithdraw(event: WithdrawEvent): Withdraw {
   vub.value = vub.value.minus(amount.times(tokenPrice))
   vub.token = token.id
 
-  vault.tvl = vault.tvl.minus(amount)
-  vault.tvlUSD = vault.tvl.times(tokenPrice).minus(amount.times(tokenPrice))
+  vault.tvlUSD = vault.tvl.times(tokenPrice)
   if (staked <= BIG_DECIMAL_0) {
     const earned = staked.times(BIG_DECIMAL_MIN_1)
     vub.earned = vub.earned.plus(earned)
@@ -56,8 +55,7 @@ export function createWithdraw(event: WithdrawEvent): Withdraw {
   saveVault(vault, timestamp)
 
   const vaultGroup = getVaultGroup(vault.name)
-  vaultGroup.tvl = vaultGroup.tvl.minus(amount)
-  vaultGroup.tvlUSD = vaultGroup.tvl.times(tokenPrice).minus(amount.times(tokenPrice))
+  vaultGroup.tvlUSD = vaultGroup.tvl.times(tokenPrice)
   vaultGroup.volume = vaultGroup.volume.plus(amount)
   vaultGroup.volumeUSD = vaultGroup.volumeUSD.plus(amount.times(tokenPrice))
   saveVaultGroup(vaultGroup, timestamp)


### PR DESCRIPTION
Replacing the daily snapshots - hourly snapshots provide more accuracy.