### PR TITLE
Create new github action to sync typechain directories

### DIFF
--- a/.github/workflows/sync-typechain-dirs.yaml
+++ b/.github/workflows/sync-typechain-dirs.yaml
@@ -1,0 +1,38 @@
+name: Sync Typechain Directories
+on:
+  pull_request:
+    branches:
+      - 'stage'
+      - 'core'
+      - 'test-new-gh-action'
+    types: 
+      - closed
+    paths:
+      - 'protocol/contracts/**'
+
+jobs:
+  align_typechain_dir:
+    name: Sync Typechain Directories
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '16'
+          cache: 'yarn'
+      - run: |
+          yarn install
+          yarn compile
+          ls ../apps/dapp/src/types/
+          echo '----- Running Rsync -----'
+          rsync -avzh typechain ../apps/dapp/src/types/
+          git config user.name TempleDAO
+          git config user.email TempleDAO@github.com
+          git add ../apps/dapp/src/types/
+          git commit -m "Automated Action: Update Dapp Typechain Types"
+          git status
+          echo '---- Trying to push ----'
+          echo ${{ github.event.pull_request.merged }}
+          git push
+        working-directory: protocol

--- a/.github/workflows/sync-typechain-dirs.yaml
+++ b/.github/workflows/sync-typechain-dirs.yaml
@@ -4,7 +4,6 @@ on:
     branches:
       - 'stage'
       - 'core'
-      - 'test-new-gh-action'
     types: 
       - closed
     paths:

--- a/.github/workflows/sync-typechain-dirs.yaml
+++ b/.github/workflows/sync-typechain-dirs.yaml
@@ -25,16 +25,16 @@ jobs:
         run: |
           yarn install
           yarn compile
+        working-directory: protocol
       - name : Sync Directories
         run : |
-          rsync -avzh typechain ../apps/dapp/src/types/
+          rsync -avzh ./protocol/typechain ./apps/dapp/src/types/
       - name: Setting up git 
         run : |
-          git config user.name TempleDAO
-          git config user.email TempleDAO@github.com
+          git config user.name github-actions
+          git config user.email github-actions@github.com
       - name: Pushing Automated Commit
         run: |
-          git add ../apps/dapp/src/types/
+          git add ./apps/dapp/src/types/
           git commit -m "Automated Action: Update Dapp Typechain Types"
           git push
-        working-directory: protocol

--- a/.github/workflows/sync-typechain-dirs.yaml
+++ b/.github/workflows/sync-typechain-dirs.yaml
@@ -21,18 +21,20 @@ jobs:
         with:
           node-version: '16'
           cache: 'yarn'
-      - run: |
+      - name : Yarn Commands
+        run: |
           yarn install
           yarn compile
-          ls ../apps/dapp/src/types/
-          echo '----- Running Rsync -----'
+      - name : Sync Directories
+        run : |
           rsync -avzh typechain ../apps/dapp/src/types/
+      - name: Setting up git 
+        run : |
           git config user.name TempleDAO
           git config user.email TempleDAO@github.com
+      - name: Pushing Automated Commit
+        run: |
           git add ../apps/dapp/src/types/
           git commit -m "Automated Action: Update Dapp Typechain Types"
-          git status
-          echo '---- Trying to push ----'
-          echo ${{ github.event.pull_request.merged }}
           git push
         working-directory: protocol


### PR DESCRIPTION
# Description
What does this PR solve?

Whenever there is a change in the contracts we have to generate new typechain files. This github action automates that whenever a PR is sucessfully merged that changes anything in `protocol/contracts/**`

Fixes #271 

# Checklist
- [x] Code follows the style guide
- [x] I have performed a self-review of my own code
- [x] New and existing tests pass locally
- [x] This PR is targeting the correct branch 

# Notes:
- We have to use `yarn compile` and generate the files in the container that the GH Action runs in because `protocol/typechain` is in .gitignore and doesn't get included in the container when it spins up
- You can check/open a PR to see the GH Action working on my [fork](https://github.com/BoxedFruits/temple-dev/pull/25). [Link to my actions dashboard](https://github.com/BoxedFruits/temple-dev/actions/runs/2943020524)