### PR TITLE
Fix vercel api deployments

### DIFF
--- a/.vercelignore
+++ b/.vercelignore
@@ -1,5 +1,6 @@
 /apps/*
 !/apps/dapp
+!/apps/api
 /protocol
 /shared
 /utils


### PR DESCRIPTION
# Description

API deployments currently broken because the apps/api directory is ignored by vercel. This PR un-ignores it.

# Checklist
- [ ] Code follows the style guide
- [ ] I have performed a self-review of my own code
- [ ] New and existing tests pass locally
- [ ] This PR is targeting the correct branch 