### PR TITLE
Fix slippage calculations, remove SlippageTooHigh state

### DIFF
--- a/apps/dapp/src/components/Pages/Core/Trade/constants.ts
+++ b/apps/dapp/src/components/Pages/Core/Trade/constants.ts
@@ -28,7 +28,6 @@ export const INITIAL_STATE: SwapReducerState = {
   outputConfig: buildValueConfig(TICKER_SYMBOL.TEMPLE_TOKEN),
   buttonLabel: createButtonLabel(TICKER_SYMBOL.FRAX, TICKER_SYMBOL.TEMPLE_TOKEN, SwapMode.Buy),
   isTransactionPending: false,
-  isSlippageTooHigh: false,
   isFraxSellDisabled: false,
   error: null,
 };

--- a/apps/dapp/src/components/Pages/Core/Trade/reducer.ts
+++ b/apps/dapp/src/components/Pages/Core/Trade/reducer.ts
@@ -69,7 +69,6 @@ export function swapReducer(state: SwapReducerState, action: SwapReducerAction):
     case 'changeTxSettings':
       return {
         ...state,
-        isSlippageTooHigh: false,
         slippageTolerance: action.value.slippageTolerance,
         deadlineMinutes: action.value.deadlineMinutes,
         buttonLabel: createButtonLabel(state.inputToken, state.outputToken, state.mode),
@@ -88,15 +87,8 @@ export function swapReducer(state: SwapReducerState, action: SwapReducerAction):
     case 'txSuccess':
       return {
         ...state,
-        inputValue: state.isSlippageTooHigh ? state.inputValue : INITIAL_STATE.inputValue,
-        quoteValue: state.isSlippageTooHigh ? state.quoteValue : INITIAL_STATE.quoteValue,
-      };
-
-    case 'slippageTooHigh':
-      return {
-        ...state,
-        isSlippageTooHigh: true,
-        buttonLabel: 'INCREASE SLIPPAGE TOLERANCE',
+        inputValue: INITIAL_STATE.inputValue,
+        quoteValue: INITIAL_STATE.quoteValue,
       };
 
     case 'disableFraxSell':

--- a/apps/dapp/src/components/Pages/Core/Trade/types.ts
+++ b/apps/dapp/src/components/Pages/Core/Trade/types.ts
@@ -49,7 +49,6 @@ export interface SwapReducerState {
   outputConfig: SwapInputConfig;
   buttonLabel: string;
   isTransactionPending: boolean;
-  isSlippageTooHigh: boolean;
   isFraxSellDisabled: boolean;
   error: Error | null;
 }

--- a/apps/dapp/src/components/Pages/Core/Trade/views/Trade.tsx
+++ b/apps/dapp/src/components/Pages/Core/Trade/views/Trade.tsx
@@ -19,6 +19,7 @@ import {
   ErrorLabel,
 } from '../styles';
 import { ZERO } from 'utils/bigNumber';
+import { INITIAL_STATE } from '../constants';
 
 export const Trade = () => {
   const {
@@ -40,17 +41,13 @@ export const Trade = () => {
 
   const bigInputValue = getBigNumberFromString(state.inputValue || '0');
   
-  const isButtonDisabled =
-    !state.isSlippageTooHigh &&
-    (state.isTransactionPending ||
-      state.inputTokenBalance.eq(ZERO) ||
-      bigInputValue.gt(state.inputTokenBalance) ||
-      state.inputValue === '');
+  const isButtonDisabled = state.isTransactionPending || state.inputTokenBalance.eq(ZERO) ||bigInputValue.gt(state.inputTokenBalance) ||state.inputValue === '';
 
   return (
     <>
       <TransactionSettingsModal
         isOpen={isSlippageModalOpen}
+        defaultSlippage={INITIAL_STATE.slippageTolerance}
         onClose={() => setIsSlippageModalOpen(false)}
         onChange={(settings) => handleTxSettingsUpdate(settings)}
       />
@@ -82,7 +79,7 @@ export const Trade = () => {
         <Spacer />
         <CtaButton
           label={state.buttonLabel}
-          onClick={state.isSlippageTooHigh ? () => setIsSlippageModalOpen(true) : handleTransaction}
+          onClick={handleTransaction}
           disabled={isButtonDisabled}
         />
       </SwapContainer>


### PR DESCRIPTION
# Description
- Removes `slippageTooHigh` state from the Trade reducer
- Fixes slippage calculation (it was previously multiplying slippage tolerance with the mark price rather than quoted price)
- Uses BigNumbers for slippage calculation
- Sets default slippage tolerance to 0.5%

Fixes # (issue)

# Checklist
- [ ] Code follows the style guide
- [ ] I have performed a self-review of my own code
- [ ] New and existing tests pass locally
- [ ] This PR is targeting the correct branch 