### PR TITLE
feat: UI Improvements Round 2

### DIFF
--- a/apps/dapp/src/components/Input/VaultInput.tsx
+++ b/apps/dapp/src/components/Input/VaultInput.tsx
@@ -129,14 +129,7 @@ export const InputWrapper = styled.div<InputWrapperProps>`
   ${tabletAndAbove(`
     padding: 1rem 1.5rem /* 12/16 */;  
   `)}
-}
-
-${(props) =>
-  props.isDisabled &&
-  css`
-    background-color: ${(props) => props.theme.palette.brand25};
-  `}
-`;
+}`;
 
 const InputTokenWrapper = styled.div`
   position: relative;

--- a/apps/dapp/src/components/Pages/Core/VaultPages/Claim.tsx
+++ b/apps/dapp/src/components/Pages/Core/VaultPages/Claim.tsx
@@ -21,7 +21,8 @@ export const Claim = () => {
   const vault = activeVault!;
 
   const [amount, setAmount] = useState<string>('');
-  const [{ balance, isLoading: getBalanceLoading }, getBalance] = useVaultBalance(vault.id);
+  const [{ balance, isLoading: getBalanceLoading, nextClaimDate }, getBalance] = useVaultBalance(vault.id);
+  const showNextClaimDate = nextClaimDate !== null;
   const [{ isLoading: refreshLoading }, refreshWalletState] = useRefreshWalletState();
   const [withdraw, { isLoading: withdrawIsLoading, error }] = useWithdrawFromVault(vault!.id, async () => {
     await refreshWalletState();
@@ -58,7 +59,7 @@ export const Claim = () => {
     </ClaimableLabel>
   ) : (
     <ClaimableLabel>
-      Nothing to claim
+      {showNextClaimDate ? `You can next claim on ${nextClaimDate}` : 'Nothing to claim.'}
       <TempleAmountLink>&nbsp; {/* Note: this node is here for formatting/spacing */}</TempleAmountLink>
     </ClaimableLabel>
   );

--- a/apps/dapp/src/components/Pages/Core/VaultPages/Stake.tsx
+++ b/apps/dapp/src/components/Pages/Core/VaultPages/Stake.tsx
@@ -81,6 +81,7 @@ export const Stake = () => {
 
   const [{ allowance, isLoading: allowanceLoading }, increaseAllowance] = useTokenVaultProxyAllowance(ticker);
 
+  const showDropdown = options.length > 1;
   const handleUpdateStakingAmount = (value: string) => {
     const amount = Number(value || '0');
 
@@ -190,15 +191,19 @@ export const Stake = () => {
       <DepositContainer>
         Deposit{' '}
         <SelectContainer>
-          <CryptoSelect
-            isSearchable={false}
-            options={options}
-            defaultValue={options[0]}
-            onChange={(val: Option) => {
-              setOption(val.value as TICKER_SYMBOL);
-              handleUpdateStakingAmount('');
-            }}
-          />
+          {showDropdown ? (
+            <CryptoSelect
+              isSearchable={false}
+              options={options}
+              defaultValue={options[0]}
+              onChange={(val: Option) => {
+                setOption(val.value as TICKER_SYMBOL);
+                handleUpdateStakingAmount('');
+              }}
+            />
+          ) : (
+            <TempleText>$TEMPLE</TempleText>
+          )}
         </SelectContainer>
       </DepositContainer>
       <VaultInput
@@ -281,7 +286,6 @@ const useStakeOptions = () => {
 
 const SelectContainer = styled.div`
   margin: 0 auto;
-  width: 50%;
   padding: 1rem;
   display: inline-block;
   z-index: 4;
@@ -311,4 +315,8 @@ const JoiningFee = styled.span`
   display: block;
   padding: 1rem 0 0;
   font-size: 1.4rem;
+`;
+
+const TempleText = styled.div`
+  min-height: 47px;
 `;

--- a/apps/dapp/src/components/Pages/Core/VaultPages/Summary.tsx
+++ b/apps/dapp/src/components/Pages/Core/VaultPages/Summary.tsx
@@ -11,6 +11,8 @@ import { useVaultMetrics } from 'hooks/core/subgraph';
 import EllipsisLoader from 'components/EllipsisLoader';
 import useRefreshableTreasuryMetrics from 'hooks/use-refreshable-treasury-metrics';
 import { FALLBACK_VAULT_APY } from '../Trade/constants';
+import socialDocsIcon from 'assets/images/social-docs.png';
+import Image from 'components/Image/Image';
 
 export const Summary = () => {
   const navigate = useNavigate();
@@ -25,19 +27,28 @@ export const Summary = () => {
     navigate(`/dapp/vaults/${vaultGroup!.id}/strategy`);
   };
 
-  const tvl = response?.data?.metrics[0]?.tvlUSD;
+  const userTvl=vaultGroup?.tvl;
+
+  const totalTvl = response?.data?.metrics[0]?.tvlUSD;
 
   return (
     <VaultContent>
-      <Title>1 MONTH</Title>
-      <Text2 light as="a" href={`/dapp/vaults/${vaultGroup!.id}/strategy`} onClick={onClickLink}>
-        1 Month Vault
-      </Text2>
+      <Title as="a" href={`/dapp/vaults/${vaultGroup!.id}/strategy`} onClick={onClickLink}>1 MONTH</Title>
       <Text3>
         <>
-          TVL: <>{isLoading || !tvl ? <EllipsisLoader /> : `$${formatNumberWithCommas(tvl)}`}</>{' '}
-          {!!tvl && (
+          TVL: <>{isLoading || !totalTvl ? <EllipsisLoader /> : `$${formatNumberWithCommas(totalTvl)}`}</>{' '}
+          {!!totalTvl && (
             <Tooltip content="Total Value Locked for this vault" inline={true}>
+              ⓘ
+            </Tooltip>
+          )}
+        </>
+      </Text3>
+      <Text3>
+        <>
+          User Locked: <>{isLoading || !userTvl ? <EllipsisLoader /> : `${formatNumberWithCommas(userTvl)}`} $TEMPLE</>{' '}
+          {!!userTvl && (
+            <Tooltip content="User's Value Locked for this vault" inline={true}>
               ⓘ
             </Tooltip>
           )}
@@ -51,6 +62,11 @@ export const Summary = () => {
         >
           ⓘ
         </Tooltip>
+      </Text3>
+      <Text3>
+        <a href="https://templedao.medium.com/" target="_blank">
+          <Image src={socialDocsIcon} alt={''} width={24} height={24} /> Learn More
+        </a>
       </Text3>
     </VaultContent>
   );
@@ -95,3 +111,4 @@ const Text3 = styled.div<{ light?: boolean }>`
   text-shadow: ${COLOR_PERCENTAGE_TEXT_SHADOW};
   color: ${({ theme, light }) => (light ? theme.palette.brandLight : theme.palette.brand)};
 `;
+

--- a/apps/dapp/src/components/Pages/Core/VaultPages/Timing.tsx
+++ b/apps/dapp/src/components/Pages/Core/VaultPages/Timing.tsx
@@ -21,9 +21,6 @@ const Timing = () => {
                 Sub-Vault
               </Cell>
               <Cell $align="center" as="th">
-                Staked
-              </Cell>
-              <Cell $align="center" as="th">
                 Balance
               </Cell>
               <Cell $align="center" as="th">
@@ -39,7 +36,6 @@ const Timing = () => {
               return (
                 <Row key={vault.id}>
                   <Cell $align="center">{vault.isActive ? `> ${vault.label} <` : vault.label}</Cell>
-                  <Cell $align="center">{formatTemple(vaultBalance.staked)} $T</Cell>
                   <Cell $align="center">{formatTemple(vaultBalance.balance)} $T</Cell>
                   <Cell $align="center">{unlockValue}</Cell>
                 </Row>

--- a/apps/dapp/src/hooks/core/use-vault-balance.tsx
+++ b/apps/dapp/src/hooks/core/use-vault-balance.tsx
@@ -1,12 +1,14 @@
 import { BigNumber } from 'ethers';
 import { useVaultContext } from 'components/Pages/Core/VaultContext';
 import { ZERO } from 'utils/bigNumber';
+import { format, isDate } from 'date-fns';
 
 type HookResponseType = [
   {
     isLoading: boolean;
     balance: BigNumber;
     staked: BigNumber;
+    nextClaimDate: string | null
   },
   () => Promise<void>
 ];
@@ -18,16 +20,27 @@ const DEFAULT_STATE = {
 };
 
 export const useVaultBalance = (vaultContractAddress: string): HookResponseType => {
-  const { balances: { balances, isLoading }, refreshVaultBalance, vaultGroup } = useVaultContext();
+  const { balances: { balances, isLoading }, refreshVaultBalance, vaultGroup, vaultGroups } = useVaultContext();
   const fetchBalance = () => refreshVaultBalance(vaultContractAddress);
   const vaultGroupBalances = balances[vaultGroup!.id];
   const vaultBalance = vaultGroupBalances[vaultContractAddress] || DEFAULT_STATE;
+
+  let nextClaimDate = null;
+  const futureClaimableSubvaults = vaultGroups.vaultGroups[0].vaults.filter(vault => !vault.isActive && vault.tvl>0);
+  
+  if (futureClaimableSubvaults.length > 0) {
+    const nextClaimableVault = futureClaimableSubvaults[0];
+    if (isDate(nextClaimableVault.unlockDate)) {
+      nextClaimDate = format(nextClaimableVault.unlockDate as Date, 'MMM do');
+    }
+  }
 
   return [
     {
       isLoading,
       balance: vaultBalance.balance || DEFAULT_STATE.balance,
       staked: vaultBalance.staked || DEFAULT_STATE.staked,
+      nextClaimDate: nextClaimDate
     },
     fetchBalance,
   ];


### PR DESCRIPTION
# Description

Based on the spreadsheet, this PR addresses the following UI improvements:

Vault - Summary page:
- Add help link to bottom of summary page
- Add users total holdings
- Remove duplication of Vault title

Vault - Stake page:
- Remove deposit dropdown if only 1 option

Vault - Claim page:
- Add a date when the user’s assets will next be claimable (if nothing claimable now)
- Change input field styling to match other fields (remove orange/brown background). Note this is only when nothing is claimable (disabled state)

Vault - Timing page:
- Remove “staked” columns, just show “balance”, the users current total holdings in that subvault


# Checklist
- [ ] Code follows the style guide
- [ ] I have performed a self-review of my own code
- [ ] New and existing tests pass locally
- [ ] This PR is targeting the correct branch 