### PR TITLE
Honey pot mint pass

### DIFF
--- a/protocol/contracts/core/bera/HoneyPot.sol
+++ b/protocol/contracts/core/bera/HoneyPot.sol
@@ -38,6 +38,7 @@ contract HoneyPot is ERC721, EIP712, Ownable, Pausable {
 
     function setVerifier(address _verifier) external onlyOwner {
         verifier = _verifier;
+        emit SetVerifier(verifier);
     }
 
     /**
@@ -117,5 +118,7 @@ contract HoneyPot is ERC721, EIP712, Ownable, Pausable {
         super._beforeTokenTransfer(from, to, tokenId);
         require(from == address(0) || to == address(0), "HoneyPot can't be transferred");
     }
+
+    event SetVerifier(address verifier);
     
 }

--- a/protocol/contracts/core/bera/HoneyPot.sol
+++ b/protocol/contracts/core/bera/HoneyPot.sol
@@ -1,0 +1,121 @@
+pragma solidity ^0.8.4;
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import "@openzeppelin/contracts/utils/cryptography/draft-EIP712.sol";
+import "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
+import "@openzeppelin/contracts/token/ERC721/ERC721.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
+import "@openzeppelin/contracts/security/Pausable.sol";
+import "@openzeppelin/contracts/utils/Counters.sol";
+
+
+/**
+ * @title HoneyPost Mint Shard Pass
+ *
+ * @dev Gives Puzzle solvers whitelist to enter the honey pot vault
+ *
+ */
+contract HoneyPot is ERC721, EIP712, Ownable, Pausable {
+
+    using Counters for Counters.Counter;
+
+    address public verifier;
+    mapping(address => bool) public minted;
+
+    Counters.Counter private _tokenIdTracker;
+
+    bytes32 public immutable VERIFY_TYPEHASH = keccak256("mint(address account)");
+
+ 
+    constructor(
+        string memory _name,
+        string memory _symbol,
+        address _verifier
+    ) ERC721(_name, _symbol) EIP712(_name, "1") {
+        verifier = _verifier;
+    }
+
+
+    function setVerifier(address _verifier) external onlyOwner {
+        verifier = _verifier;
+    }
+
+    /**
+     * @dev Pause minting of tokens
+     *
+     *  Requirements:
+     *  caller must be admin
+     */
+    function pause() external onlyOwner {
+         _pause();
+    }
+
+    /**
+     * @dev UnPause minting of tokens
+     *
+     *  Requirements:
+     *  caller must be admin
+     */
+    function unpause() external onlyOwner {
+        _unpause();
+    }
+    
+
+    /**
+     * @dev Creates a new token for `msg.sender`. Its token ID will be automatically
+     * assigned. 
+     *
+     * Requirements:
+     *
+     * - User must have completed pussle and got a signature of completion from dapp
+     */
+    function mint(uint8 v, bytes32 r, bytes32 s) public virtual whenNotPaused {
+
+      require(!minted[msg.sender], "Already Minted");
+
+      bytes32 structHash = keccak256(abi.encode(VERIFY_TYPEHASH, msg.sender));
+      bytes32 digest = _hashTypedDataV4(structHash);
+      address signer = ECDSA.recover(digest, v, r, s);
+
+      require(signer == verifier, "invalid signature");
+      _mint(msg.sender, _tokenIdTracker.current());
+      _tokenIdTracker.increment();
+
+      minted[msg.sender] = true;
+    }
+
+
+    /**
+     * Generate a digest (to be signed off-chain by the verified private key)
+     */
+    function digestFor(address account) public view returns(bytes32 digest) {
+      bytes32 structHash = keccak256(abi.encode(VERIFY_TYPEHASH, account));
+      digest = _hashTypedDataV4(structHash);
+    }
+
+
+    /**
+     * @dev See {IERC20Permit-DOMAIN_SEPARATOR}.
+     */
+    // solhint-disable-next-line func-name-mixedcase
+    function DOMAIN_SEPARATOR() external view returns (bytes32) {
+        return _domainSeparatorV4();
+    }
+
+    /**
+     * @dev See {ERC721-_beforeTokenTransfer}.
+     *
+     * Requirements:
+     *
+     * - token is non-transferable. Only mint and burn allowed
+     */
+    function _beforeTokenTransfer(
+        address from,
+        address to,
+        uint256 tokenId
+    ) internal virtual override {
+        super._beforeTokenTransfer(from, to, tokenId);
+        require(from == address(0) || to == address(0), "HoneyPot can't be transferred");
+    }
+    
+}

--- a/protocol/contracts/core/bera/HoneyPot.sol
+++ b/protocol/contracts/core/bera/HoneyPot.sol
@@ -86,10 +86,10 @@ contract HoneyPot is ERC721, EIP712, Ownable, Pausable {
       if (signer != verifier) {
           revert InvalidSignature();
       }
+      minted[msg.sender] = true;
       _mint(msg.sender, _tokenIdTracker.current());
       _tokenIdTracker.increment();
 
-      minted[msg.sender] = true;
     }
 
 

--- a/protocol/test/core/bera/honey-post-tests.ts
+++ b/protocol/test/core/bera/honey-post-tests.ts
@@ -63,7 +63,7 @@ describe("HoneyPot Mint Pass", async () => {
 
 
         // User can't mint again
-        await shouldThrow(honeyPot.connect(verifiedMinter).mint(signature.v, signature.r, signature.s), /Already Minted/);
+        await shouldThrow(honeyPot.connect(verifiedMinter).mint(signature.v, signature.r, signature.s), /AlreadyMinted/);
     })
 
     it("non-verified user can't mint", async () => {
@@ -71,7 +71,7 @@ describe("HoneyPot Mint Pass", async () => {
         const digest = await honeyPot.digestFor(await verifiedMinter.getAddress());
         const signature = verifier._signingKey().signDigest(digest)
 
-        await shouldThrow(honeyPot.connect(nonVerifiedMinter).mint(signature.v, signature.r, signature.s), /invalid signature/);
+        await shouldThrow(honeyPot.connect(nonVerifiedMinter).mint(signature.v, signature.r, signature.s), /InvalidSignature/);
     })
 
 
@@ -80,7 +80,7 @@ describe("HoneyPot Mint Pass", async () => {
         const digest = await honeyPot.digestFor(await verifiedMinter.getAddress());
         const signature = verifier._signingKey().signDigest(digest)
         await honeyPot.connect(verifiedMinter).mint(signature.v, signature.r, signature.s)
-        await shouldThrow(honeyPot.connect(verifiedMinter).transferFrom(await verifiedMinter.getAddress(), await nonVerifiedMinter.getAddress(), 0), /HoneyPot can't be transferred/);
+        await shouldThrow(honeyPot.connect(verifiedMinter).transferFrom(await verifiedMinter.getAddress(), await nonVerifiedMinter.getAddress(), 0), /NonTransferrable/);
     })
 
 })

--- a/protocol/test/core/bera/honey-post-tests.ts
+++ b/protocol/test/core/bera/honey-post-tests.ts
@@ -1,0 +1,86 @@
+import { ethers } from "hardhat";
+import { expect } from "chai";
+import { Signer, Wallet } from "ethers";
+import { 
+    HoneyPot,
+    HoneyPot__factory,
+} from "../../../typechain";
+import { shouldThrow } from "../../helpers";
+
+describe("HoneyPot Mint Pass", async () => { 
+
+    let honeyPot: HoneyPot
+    let owner: Signer
+    let nonOwner: Signer
+    let verifiedMinter: Signer
+    let nonVerifiedMinter: Signer
+
+    let verifier: Wallet
+    let fakeVerifier: Wallet
+
+    beforeEach(async () => {
+        [owner, nonOwner, verifiedMinter, nonVerifiedMinter] = (await ethers.getSigners()) as Signer[];
+    
+        verifier = ethers.Wallet.createRandom()
+        fakeVerifier = ethers.Wallet.createRandom()
+    
+        honeyPot = await new HoneyPot__factory(owner).deploy(
+             "Honey Pot Mint Pass",
+             "HP",
+             verifier.address,
+        );
+    })
+
+    it("Only owner can change verifier", async () => {
+        await shouldThrow(honeyPot.connect(nonOwner).setVerifier(await fakeVerifier.getAddress()), /Ownable:/);
+        await honeyPot.connect(owner).setVerifier(await fakeVerifier.getAddress());
+        expect(await honeyPot.verifier()).eq(await fakeVerifier.getAddress());
+    });
+
+    it("Only owner can pause & unpause minting", async () => {
+        // Not owner
+        await shouldThrow(honeyPot.connect(nonOwner).pause(), /Ownable:/);
+        await shouldThrow(honeyPot.connect(nonOwner).unpause(), /Ownable:/);
+
+        // Owner
+        await honeyPot.connect(owner).pause()
+        expect(await honeyPot.paused()).eq(true);
+
+        // Can't mint when Pause
+        await shouldThrow(honeyPot.connect(nonOwner).mint(0, "0xb2dbf9d78de484989ffa46e822fadc46edf4b43c3d49ab1c0e15e71d02d46f7b", "0xb2dbf9d78de484989ffa46e822fadc46edf4b43c3d49ab1c0e15e71d02d46f7b"), /Pausable: paused/);
+
+    });
+
+    it("verified user can mint once", async () => {
+
+        expect(await honeyPot.minted(await verifiedMinter.getAddress())).eq(false);
+
+        const digest = await honeyPot.digestFor(await verifiedMinter.getAddress());
+        const signature = verifier._signingKey().signDigest(digest)
+
+        await honeyPot.connect(verifiedMinter).mint(signature.v, signature.r, signature.s)
+        expect(await honeyPot.minted(await verifiedMinter.getAddress())).eq(true);
+
+
+        // User can't mint again
+        await shouldThrow(honeyPot.connect(verifiedMinter).mint(signature.v, signature.r, signature.s), /Already Minted/);
+    })
+
+    it("non-verified user can't mint", async () => {
+
+        const digest = await honeyPot.digestFor(await verifiedMinter.getAddress());
+        const signature = verifier._signingKey().signDigest(digest)
+
+        await shouldThrow(honeyPot.connect(nonVerifiedMinter).mint(signature.v, signature.r, signature.s), /invalid signature/);
+    })
+
+
+    it("can't transfer the token", async () => {
+
+        const digest = await honeyPot.digestFor(await verifiedMinter.getAddress());
+        const signature = verifier._signingKey().signDigest(digest)
+        await honeyPot.connect(verifiedMinter).mint(signature.v, signature.r, signature.s)
+        await shouldThrow(honeyPot.connect(verifiedMinter).transferFrom(await verifiedMinter.getAddress(), await nonVerifiedMinter.getAddress(), 0), /HoneyPot can't be transferred/);
+    })
+
+})


### PR DESCRIPTION
# Description
What does this PR solve?
A Non transferable NFT minted for users solving cryptovoxels puzzle. The nft while allow people to be able to participate in the honey post vault.

When completing the puzzle the user will get a signature which they can use to mint the NFT.

Fixes # (issue)

# Checklist
- [ ] Code follows the style guide
- [ ] I have performed a self-review of my own code
- [ ] New and existing tests pass locally
- [ ] This PR is targeting the correct branch 