### PR TITLE
Ramos addliquidity update

### DIFF
--- a/apps/dapp/src/components/Pages/Ramos/admin/components/AddLiquidity.tsx
+++ b/apps/dapp/src/components/Pages/Ramos/admin/components/AddLiquidity.tsx
@@ -1,42 +1,43 @@
 import { Button } from 'components/Button/Button';
 import { Input } from 'components/Input/Input';
-import { BigNumber, ethers } from 'ethers';
+import { TICKER_SYMBOL } from 'enums/ticker-symbol';
+import { BigNumber } from 'ethers';
 import { useState } from 'react';
-import { ZERO } from 'utils/bigNumber';
+import { PoolHelper } from 'types/typechain';
+import { DBN_ZERO, DecimalBigNumber } from 'utils/DecimalBigNumber';
 import { InputArea, RequestArea } from '../styles';
 
 interface IProps {
+  handleInput: (
+    stableAmount: DecimalBigNumber
+  ) => Promise<{ templeAmount: DecimalBigNumber; stableAmount: DecimalBigNumber }>;
   calculateFunc: (
     templeAmount: BigNumber,
     stableAmount: BigNumber
   ) => Promise<{ joinPoolRequest: string; minBptOut: string } | undefined>;
 }
-export const AddLiquidity: React.FC<IProps> = ({ calculateFunc }) => {
-  const [amounts, setAmounts] = useState({ temple: ZERO, stable: ZERO });
-  const [joinPoolInfo, setJoinPoolInfo] = useState<{ joinPoolRequest: string; minBptOut: string }>();
 
+export const AddLiquidity: React.FC<IProps> = ({ calculateFunc, handleInput }) => {
+  const [amounts, setAmounts] = useState({ templeAmount: DBN_ZERO, stableAmount: DBN_ZERO });
+  const [joinPoolInfo, setJoinPoolInfo] = useState<{ joinPoolRequest: string; minBptOut: string }>();
   return (
     <InputArea>
       <h3>AddLiquidity</h3>
       <Input
-        crypto={{ kind: 'value', value: 'TEMPLE' }}
-        small
-        handleChange={(e: string) => {
-          if (Number(e)) setAmounts({ ...amounts, temple: ethers.utils.parseUnits(e) });
-        }}
-      />
-      <Input
         crypto={{ kind: 'value', value: 'STABLE' }}
         small
-        handleChange={(e: string) => {
-          if (Number(e)) setAmounts({ ...amounts, stable: ethers.utils.parseUnits(e) });
+        handleChange={async (e: string) => {
+          if (Number(e)) {
+            setAmounts(await handleInput(DecimalBigNumber.parseUnits(e, 18)));
+          } else setAmounts({ templeAmount: DBN_ZERO, stableAmount: DBN_ZERO });
         }}
       />
+      <Input disabled value={amounts.templeAmount.formatUnits()} crypto={{ kind: 'value', value: 'TEMPLE' }} small />
       <Button
         isSmall
         label="CREATE REQUEST PARAMS"
         onClick={async () => {
-          const poolInfo = await calculateFunc(amounts.temple, amounts.stable);
+          const poolInfo = await calculateFunc(amounts.templeAmount.toBN(18), amounts.stableAmount.toBN(18));
           setJoinPoolInfo(poolInfo);
         }}
       />

--- a/apps/dapp/src/components/Pages/Ramos/admin/components/AddLiquidity.tsx
+++ b/apps/dapp/src/components/Pages/Ramos/admin/components/AddLiquidity.tsx
@@ -1,11 +1,11 @@
 import { Button } from 'components/Button/Button';
 import { Input } from 'components/Input/Input';
+import Tooltip, { TooltipIcon } from 'components/Tooltip/Tooltip';
 import { TICKER_SYMBOL } from 'enums/ticker-symbol';
 import { BigNumber } from 'ethers';
 import { useState } from 'react';
-import { PoolHelper } from 'types/typechain';
 import { DBN_ZERO, DecimalBigNumber } from 'utils/DecimalBigNumber';
-import { InputArea, RequestArea } from '../styles';
+import { InputArea, RequestArea, TitleWrapper } from '../styles';
 
 interface IProps {
   handleInput: (
@@ -22,7 +22,21 @@ export const AddLiquidity: React.FC<IProps> = ({ calculateFunc, handleInput }) =
   const [joinPoolInfo, setJoinPoolInfo] = useState<{ joinPoolRequest: string; minBptOut: string }>();
   return (
     <InputArea>
-      <h3>AddLiquidity</h3>
+    <TitleWrapper>
+        <h3>AddLiquidity</h3>
+        <Tooltip
+          content={
+            <>
+              <p>Add liquidity with both {TICKER_SYMBOL.TEMPLE_TOKEN} and stable tokens into balancer pool. </p>
+              <p>Treasury Price Floor is expected to be within bounds of multisig set range.</p>
+              <p>BPT tokens are then deposited and staked in Aura.</p>
+              <p>{TICKER_SYMBOL.TEMPLE_TOKEN} amount is minted by RAMOS and calculated here to preserve spot price</p>
+            </>
+          }
+        >
+          <TooltipIcon />
+        </Tooltip>
+      </TitleWrapper>
       <Input
         crypto={{ kind: 'value', value: 'STABLE' }}
         small

--- a/apps/dapp/src/components/Pages/Ramos/admin/components/RemoveLiquidity.tsx
+++ b/apps/dapp/src/components/Pages/Ramos/admin/components/RemoveLiquidity.tsx
@@ -1,9 +1,11 @@
 import { Button } from 'components/Button/Button';
 import { Input } from 'components/Input/Input';
+import Tooltip, { TooltipIcon } from 'components/Tooltip/Tooltip';
+import { TICKER_SYMBOL } from 'enums/ticker-symbol';
 import { BigNumber, ethers } from 'ethers';
 import { useState } from 'react';
 import { ZERO } from 'utils/bigNumber';
-import { InputArea, RequestArea } from '../styles';
+import { InputArea, RequestArea, TitleWrapper } from '../styles';
 
 interface IProps {
   calculateFunc: (exitAmountBpt: BigNumber) => Promise<string | undefined>;
@@ -14,7 +16,21 @@ export const RemoveLiquidity: React.FC<IProps> = ({ calculateFunc }) => {
 
   return (
     <InputArea>
-      <h3>RemoveLiquidity</h3>
+      <TitleWrapper>
+        <h3>RemoveLiquidity</h3>
+        <Tooltip
+          content={
+            <>
+              <p>Remove liquidity from balancer pool receiving both {TICKER_SYMBOL.TEMPLE_TOKEN} and stable tokens from balancer pool. </p>
+              <p>Treasury Price Floor is expected to be within bounds of multisig set range.</p>
+              <p>Withdraw and unwrap BPT tokens from Aura staking and send to balancer pool to receive both tokens.</p>
+            </>
+          }
+        >
+          <TooltipIcon />
+        </Tooltip>
+      </TitleWrapper>
+
       <Input
         crypto={{ kind: 'value', value: 'BPT' }}
         isNumber

--- a/apps/dapp/src/components/Pages/Ramos/admin/index.tsx
+++ b/apps/dapp/src/components/Pages/Ramos/admin/index.tsx
@@ -19,6 +19,7 @@ import {
 import { limitInput, handleBlur } from './helpers';
 import { TransactionSettingsModal } from 'components/TransactionSettingsModal/TransactionSettingsModal';
 import { useState } from 'react';
+import environmentConfig from 'constants/env';
 
 const Container = styled.div`
   display: grid;
@@ -37,7 +38,6 @@ const Content = styled.div`
 
 const RamosAdmin = () => {
   const {
-    ramos,
     tpf,
     templePrice,
     percentageOfGapToClose,
@@ -86,6 +86,8 @@ const RamosAdmin = () => {
     },
   ];
 
+  const ramosAddress = environmentConfig.contracts.ramos;
+
   return (
     <div>
       <TransactionSettingsModal
@@ -103,7 +105,7 @@ const RamosAdmin = () => {
       />
       <div>
         <p>
-          RAMOS: <a href={`https://etherscan.io/address/${ramos?.address}`} target="_blank">{ramos?.address ?? <EllipsisLoader />}</a>
+          RAMOS: <a href={`https://etherscan.io/address/${ramosAddress}`} target="_blank">{ramosAddress}</a>
         </p>
       </div>
       <Container>

--- a/apps/dapp/src/components/Pages/Ramos/admin/index.tsx
+++ b/apps/dapp/src/components/Pages/Ramos/admin/index.tsx
@@ -37,6 +37,7 @@ const Content = styled.div`
 
 const RamosAdmin = () => {
   const {
+    ramos,
     tpf,
     templePrice,
     percentageOfGapToClose,
@@ -44,6 +45,7 @@ const RamosAdmin = () => {
     rebalanceDownAmounts,
     depositStableAmounts,
     withdrawStableAmounts,
+    handleAddLiquidityInput,
     createJoinPoolRequest,
     createExitPoolRequest,
     createDepositAndStakeRequest,
@@ -76,7 +78,7 @@ const RamosAdmin = () => {
       label: 'Liquidity',
       content: (
         <Container>
-          <AddLiquidity calculateFunc={createJoinPoolRequest} />
+          <AddLiquidity calculateFunc={createJoinPoolRequest} handleInput={handleAddLiquidityInput}/>
           <RemoveLiquidity calculateFunc={createExitPoolRequest} />
           <DepositAndStakeBpt calculateFunc={createDepositAndStakeRequest} />
         </Container>
@@ -99,6 +101,11 @@ const RamosAdmin = () => {
           setSlippageTolerance(settings.slippageTolerance);
         }}
       />
+      <div>
+        <p>
+          RAMOS: <a href={`https://etherscan.io/address/${ramos?.address}`} target="_blank">{ramos?.address ?? <EllipsisLoader />}</a>
+        </p>
+      </div>
       <Container>
         <p>
           Current Spot Price: <strong>{templePrice?.formatUnits() ?? <EllipsisLoader />}</strong>

--- a/apps/dapp/src/components/Pages/Ramos/admin/styles.ts
+++ b/apps/dapp/src/components/Pages/Ramos/admin/styles.ts
@@ -20,3 +20,12 @@ export const RequestArea = styled.code`
   overflow-wrap: anywhere;
   color: ${({ theme }) => theme.palette.brand}
 `;     
+
+export const TitleWrapper = styled.div`
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  small {
+    margin-top: 0.5rem;
+  }
+`;

--- a/apps/dapp/src/components/Pages/Ramos/admin/useRamosAdmin.ts
+++ b/apps/dapp/src/components/Pages/Ramos/admin/useRamosAdmin.ts
@@ -313,7 +313,6 @@ export function useRamosAdmin() {
   };
 
   return {
-    ramos,
     tpf,
     templePrice,
     percentageOfGapToClose,

--- a/apps/dapp/src/components/Pages/Ramos/admin/useRamosAdmin.ts
+++ b/apps/dapp/src/components/Pages/Ramos/admin/useRamosAdmin.ts
@@ -127,6 +127,14 @@ export function useRamosAdmin() {
     setInitAmounts();
   }, [isConnected]);
 
+  const handleAddLiquidityInput = async (stableAmount: DecimalBigNumber) => {
+    let templeAmount = DBN_ZERO;
+    if(isConnected) {
+      templeAmount = stableAmount.mul(templePrice);
+    }
+    return {templeAmount: templeAmount, stableAmount: stableAmount}
+  }
+
   const createJoinPoolRequest = async (templeAmount: BigNumber, stableAmount: BigNumber) => {
     if (isConnected) {
       const tokenAddrs = [tokens.temple.address, tokens.stable.address];
@@ -305,6 +313,7 @@ export function useRamosAdmin() {
   };
 
   return {
+    ramos,
     tpf,
     templePrice,
     percentageOfGapToClose,
@@ -313,6 +322,7 @@ export function useRamosAdmin() {
     depositStableAmounts,
     withdrawStableAmounts,
     createJoinPoolRequest,
+    handleAddLiquidityInput,
     createExitPoolRequest,
     createDepositAndStakeRequest,
     setPercentageOfGapToClose,


### PR DESCRIPTION
# Description
Fixes AddLiquidity on the RAMOS admin screen by 
- Only allowing user to enter stable amount
- Auto-calculating TEMPLE amount based on temple/stable ratio

Also addresses requests: 
- Adds a link to RAMOS contract etherscan 
- Adds description of add/remove liquidity 

Fixes # (issue)

# Checklist
- [ ] Code follows the style guide
- [ ] I have performed a self-review of my own code
- [ ] New and existing tests pass locally
- [ ] This PR is targeting the correct branch 