### PR TITLE
Add OGT unlocking to unstake modal

### DIFF
--- a/apps/dapp/src/components/Pages/Core/NewUI/ClaimModal.tsx
+++ b/apps/dapp/src/components/Pages/Core/NewUI/ClaimModal.tsx
@@ -41,6 +41,7 @@ export const ClaimModal: React.FC<IProps> = ({ isOpen, onClose }) => {
     if (!balancesIsLoading && !vaultGroupsIsLoading) {
       const vaultGroup = vaultGroups[0];
       setAssumedActiveVaultGroup(vaultGroup);
+      if (!vaultGroup) return;
       const initialVault = vaultGroup.vaults[0];
       setClaimState({
         claimSubvaultAddress: initialVault.id,
@@ -79,9 +80,6 @@ export const ClaimModal: React.FC<IProps> = ({ isOpen, onClose }) => {
     return vaults.map((vault) => {
       const vaultGroupBalances = balances[vaultGroups[0].id];
       const vaultBalance = vaultGroupBalances[vault.id] || {};
-
-      // Empty balances won't render
-      // if (!vaultBalance.balance || vaultBalance.balance?.lte(ZERO)) return;
 
       return (
         <div key={vault.id}>

--- a/apps/dapp/src/components/Pages/Core/NewUI/UnstakeModal.tsx
+++ b/apps/dapp/src/components/Pages/Core/NewUI/UnstakeModal.tsx
@@ -43,12 +43,14 @@ export const UnstakeOgtModal: React.FC<IProps> = ({ isOpen, onClose }) => {
 
   const handleUnlockOGT = async () => {
     try {
-      await Promise.all(lockedEntries.map((entry) => claimOgTemple(entry.index)));
+      lockedEntries.map(async (entry) => {
+        await claimOgTemple(entry.index);
+        updateLockedEntries();
+        updateBalance();
+      });
     } catch (e) {
       console.log(e);
     }
-    updateLockedEntries();
-    updateBalance();
   };
 
   return (

--- a/apps/dapp/src/components/Pages/Core/NewUI/UnstakeModal.tsx
+++ b/apps/dapp/src/components/Pages/Core/NewUI/UnstakeModal.tsx
@@ -44,7 +44,7 @@ export const UnstakeOgtModal: React.FC<IProps> = ({ isOpen, onClose }) => {
   const handleUnlockOGT = async () => {
     try {
       lockedEntries.map(async (entry) => {
-        await claimOgTemple(entry.index);
+        if (Date.now() > entry.lockedUntilTimestamp) await claimOgTemple(0);
         updateLockedEntries();
         updateBalance();
       });

--- a/apps/dapp/src/components/Pages/Core/NewUI/UnstakeModal.tsx
+++ b/apps/dapp/src/components/Pages/Core/NewUI/UnstakeModal.tsx
@@ -79,7 +79,7 @@ export const UnstakeOgtModal: React.FC<IProps> = ({ isOpen, onClose }) => {
                     <br />
                   </span>
                 )}
-                After claiming locked OGT, you will be able to convert it to TEMPLE on this same screen.
+                After unlocking OGT, you will be able to convert it to TEMPLE on this same screen.
               </Subtitle>
             </>
           ) : (

--- a/apps/dapp/src/components/Pages/Core/NewUI/UnstakeModal.tsx
+++ b/apps/dapp/src/components/Pages/Core/NewUI/UnstakeModal.tsx
@@ -7,6 +7,8 @@ import { useEffect, useState } from 'react';
 import { useUnstakeOGTemple } from 'hooks/core/use-unstake-ogtemple';
 import { formatBigNumber, formatTemple, getBigNumberFromString } from 'components/Vault/utils';
 import { ZERO } from 'utils/bigNumber';
+import { useStaking } from 'providers/StakingProvider';
+import { BigNumber } from 'ethers';
 
 interface IProps {
   isOpen: boolean;
@@ -14,9 +16,10 @@ interface IProps {
 }
 
 export const UnstakeOgtModal: React.FC<IProps> = ({ isOpen, onClose }) => {
-  const { balance } = useWallet();
+  const { wallet, signer, balance, updateBalance } = useWallet();
   const [_, refreshWallet] = useRefreshWalletState();
   const [unstakeAmount, setUnstakeAmount] = useState<string>('');
+  const { lockedEntries, updateLockedEntries, claimOgTemple } = useStaking();
   const [unstake, { isLoading: unstakeLoading }] = useUnstakeOGTemple(() => {
     refreshWallet();
     setUnstakeAmount('');
@@ -27,33 +30,81 @@ export const UnstakeOgtModal: React.FC<IProps> = ({ isOpen, onClose }) => {
     setUnstakeAmount(amount);
   }, [balance]);
 
+  useEffect(() => {
+    const onMount = async () => {
+      if (wallet && signer) await updateLockedEntries();
+    };
+    onMount();
+  }, [wallet, signer]);
+
   const bigAmount = getBigNumberFromString(unstakeAmount || '0');
   const buttonIsDisabled =
     unstakeLoading || !unstakeAmount || balance.ogTemple.lte(ZERO) || bigAmount.gt(balance.ogTemple);
 
+  const handleUnlockOGT = async () => {
+    try {
+      await Promise.all(lockedEntries.map((entry) => claimOgTemple(entry.index)));
+    } catch (e) {
+      console.log(e);
+    }
+    updateLockedEntries();
+    updateBalance();
+  };
+
   return (
     <>
       <Popover isOpen={isOpen} onClose={onClose} closeOnClickOutside showCloseButton>
-        <UnstakeOgtContainer>
-          <UnstakeTitle>Unstake OGT</UnstakeTitle>
-          <UnstakeSubtitle>You are eligible to unstake:</UnstakeSubtitle>
-          <TempleAmountContainer>
-            <Temple>$OGTEMPLE</Temple>
-            <TempleAmount>{balance.ogTemple ? formatTemple(balance.ogTemple) : '0.00'}</TempleAmount>
-          </TempleAmountContainer>
-          <UnstakeButton disabled={buttonIsDisabled} onClick={() => unstake(unstakeAmount)}>
-            Unstake
-          </UnstakeButton>
-        </UnstakeOgtContainer>
+        <ModalContainer>
+          <Title>Unstake OGTemple</Title>
+          {/* Display Unlock if they have lockedOGT, then display Unstake */}
+          {lockedEntries.length > 0 ? (
+            <>
+              <Subtitle>You can claim locked OGTemple from the Opening Ceremony:</Subtitle>
+              <ClaimButton
+                isSmall
+                onClick={() => handleUnlockOGT()}
+                disabled={Date.now() < lockedEntries[0].lockedUntilTimestamp}
+              >
+                Claim{' '}
+                {formatTemple(lockedEntries.reduce((sum, cur) => sum.add(cur.balanceOGTemple), BigNumber.from('0')))}{' '}
+                OGTemple
+              </ClaimButton>
+              <Subtitle>
+                {lockedEntries.length > 1 && (
+                  <span>
+                    You will have {lockedEntries.length} transactions to claim your locked OGTemple.
+                    <br />
+                    <br />
+                  </span>
+                )}
+                After claiming locked OGT, you will be able to convert it to TEMPLE on this same screen.
+              </Subtitle>
+            </>
+          ) : (
+            <>
+              <Subtitle>
+                You have {balance.ogTemple ? formatTemple(balance.ogTemple) : '0.00'} OGT you can unstake and convert to
+                TEMPLE.
+              </Subtitle>
+              <ClaimButton
+                isSmall
+                disabled={buttonIsDisabled}
+                onClick={() => unstake(unstakeAmount)}
+                style={{ margin: '1rem auto 0 auto' }}
+              >
+                Unstake OGTEMPLE
+              </ClaimButton>
+            </>
+          )}
+        </ModalContainer>
       </Popover>
     </>
   );
 };
 
-const UnstakeButton = styled(Button)`
-  width: 100px;
-  height: 60px;
-  background: linear-gradient(180deg, #353535 45.25%, #101010 87.55%);
+const ClaimButton = styled(Button)`
+  background: ${({ theme }) => theme.palette.gradients.dark};
+  color: ${({ theme }) => theme.palette.brandLight};
   border: 1px solid #95613f;
   box-shadow: 0px 0px 20px rgba(222, 92, 6, 0.4);
   border-radius: 0.75rem;
@@ -61,61 +112,28 @@ const UnstakeButton = styled(Button)`
   font-size: 1rem;
   letter-spacing: 0.1rem;
   text-transform: uppercase;
-  color: #ffdec9;
-  margin-left: auto;
-  margin-right: auto;
-  margin-top: 10px;
+  width: max-content;
+  margin: 1rem auto;
 `;
 
-const TempleAmount = styled.div`
-  font-size: 36px;
-  display: flex;
-  align-items: center;
-  text-align: right;
-  color: #ffdec9;
-  padding: 20px;
+const Subtitle = styled.div`
+  color: ${({ theme }) => theme.palette.brand};
+  letter-spacing: 0.05rem;
+  line-height: 1.25rem;
 `;
 
-const Temple = styled.div`
-  font-style: normal;
-  font-size: 36px;
-  display: flex;
-  letter-spacing: 0.05em;
-  color: #ffdec9;
-  margin-right: auto;
+const Title = styled.div`
+  font-size: 1.5rem;
+  padding-bottom: 1rem;
+  color: ${({ theme }) => theme.palette.brandLight};
 `;
 
-const UnstakeSubtitle = styled.div`
-  font-style: normal;
-  font-weight: 700;
-  font-size: 16px;
-  line-height: 20px;
-  align-items: center;
-  letter-spacing: 0.1em;
-  color: #bd7b4f;
-`;
-
-const UnstakeTitle = styled.div`
-  font-size: 24px;
-  line-height: 28px;
-  display: flex;
-  align-items: center;
-  color: #bd7b4f;
-  padding-bottom: 20px;
-`;
-
-const TempleAmountContainer = styled.div`
-  display: flex;
-  flex-direction: row;
-  justify-content: space-between;
-  align-items: center;
-  margin-top: 20px;
-  margin-bottom: 20px;
-`;
-
-const UnstakeOgtContainer = styled.div`
+const ModalContainer = styled.div`
   display: flex;
   flex-direction: column;
+  justify-content: center;
+  text-align: center;
+  color: ${({ theme }) => theme.palette.brand};
   width: 350px;
 `;
 

--- a/protocol/scripts/local-dapp-dev/deploy.ts
+++ b/protocol/scripts/local-dapp-dev/deploy.ts
@@ -77,7 +77,7 @@ async function main() {
   );
 
   // stake, lock and exit some temple
-  let nLocks = 1;
+  let nLocks = 2;
   for (const account of accounts.slice(0, 5)) {
     const address = await account.getAddress();
     await templeToken.mint(address, toAtto(30000));


### PR DESCRIPTION
# Description
Fixes #749 

Users will first see Unlock prompt if they have locked OGT
<img width="455" alt="image" src="https://user-images.githubusercontent.com/12631233/216687632-18aabbf1-467d-4e2e-a635-db541064d892.png">

Then they will see the unstake prompt
<img width="467" alt="image" src="https://user-images.githubusercontent.com/12631233/216691186-a351192c-17de-490d-b2c5-71b688e08128.png">


# Checklist
- [x] Code follows the style guide
- [x] I have performed a self-review of my own code
- [x] New and existing tests pass locally
- [x] This PR is targeting the correct branch 