### PR TITLE
Store dashboard chart type in URL and Daily chart data

### DIFF
--- a/apps/dapp/src/components/Pages/Core/DappPages/Dashboard/Chart/index.tsx
+++ b/apps/dapp/src/components/Pages/Core/DappPages/Dashboard/Chart/index.tsx
@@ -2,9 +2,9 @@ import styled from 'styled-components';
 import { DashboardType } from '../DashboardContent';
 import V2StrategyMetricsChart from './V2StrategyMetricsChart';
 import { InputSelect } from 'components/InputSelect/InputSelect';
-import { isV2DailySnapshotMetric, V2DailySnapshotMetric } from '../hooks/use-dashboardv2-daily-snapshots';
+import { isV2SnapshotMetric, V2SnapshotMetric } from '../hooks/use-dashboardv2-daily-snapshots';
 import { useState } from 'react';
-import { ChartSupportedTimeInterval, DEFAULT_CHART_INTERVALS } from 'utils/time-intervals';
+import { ChartSupportedTimeInterval } from 'utils/time-intervals';
 import { IntervalToggler } from 'components/Charts';
 import { useSearchParams } from 'react-router-dom';
 
@@ -13,7 +13,7 @@ type DashboardChartProps = {
   strategyNames: string[];
 };
 
-const metricOptions: { value: V2DailySnapshotMetric; label: string }[] = [
+const metricOptions: { value: V2SnapshotMetric; label: string }[] = [
   { label: 'Total Market Value', value: 'totalMarketValueUSD' },
   { label: 'Accrued Interest', value: 'accruedInterestUSD' },
 
@@ -34,19 +34,17 @@ const DashboardChart = ({ dashboardType, strategyNames }: DashboardChartProps) =
 
   const [searchParams, setSearchParams] = useSearchParams();
 
-  const defaultMetric: V2DailySnapshotMetric = 'totalMarketValueUSD';
+  const defaultMetric: V2SnapshotMetric = 'totalMarketValueUSD';
   const chosenMetric = searchParams.get(CHART_SELECTOR_QUERY_PARAM);
-  const selectedMetric: V2DailySnapshotMetric = isV2DailySnapshotMetric(chosenMetric) ? chosenMetric : defaultMetric;
+  const selectedMetric: V2SnapshotMetric = isV2SnapshotMetric(chosenMetric) ? chosenMetric : defaultMetric;
 
   const [selectedInterval, setSelectedInterval] = useState<ChartSupportedTimeInterval>('1M');
 
   const selectMetric = (value: string) => {
-    if (isV2DailySnapshotMetric(value)) {
+    if (isV2SnapshotMetric(value)) {
       setSearchParams({ ...searchParams, [CHART_SELECTOR_QUERY_PARAM]: value });
     }
   };
-
-  const intervals = DEFAULT_CHART_INTERVALS.filter((i) => ['1W', '1M', '1Y'].includes(i.label));
 
   return (
     <>
@@ -61,11 +59,7 @@ const DashboardChart = ({ dashboardType, strategyNames }: DashboardChartProps) =
             />
           </SelectMetricContainer>
           <IntervalTogglerContainer>
-            <IntervalToggler
-              selectedInterval={selectedInterval}
-              setSelectedInterval={setSelectedInterval}
-              intervals={intervals}
-            />
+            <IntervalToggler selectedInterval={selectedInterval} setSelectedInterval={setSelectedInterval} />
           </IntervalTogglerContainer>
         </ChartHeader>
         <V2StrategyMetricsChart

--- a/apps/dapp/src/components/Pages/Core/DappPages/Dashboard/Chart/index.tsx
+++ b/apps/dapp/src/components/Pages/Core/DappPages/Dashboard/Chart/index.tsx
@@ -4,7 +4,7 @@ import V2StrategyMetricsChart from './V2StrategyMetricsChart';
 import { InputSelect } from 'components/InputSelect/InputSelect';
 import { isV2SnapshotMetric, V2SnapshotMetric } from '../hooks/use-dashboardv2-daily-snapshots';
 import { useState } from 'react';
-import { ChartSupportedTimeInterval } from 'utils/time-intervals';
+import { ChartSupportedTimeInterval, DEFAULT_CHART_INTERVALS } from 'utils/time-intervals';
 import { IntervalToggler } from 'components/Charts';
 import { useSearchParams } from 'react-router-dom';
 
@@ -53,7 +53,7 @@ const DashboardChart = ({ dashboardType, strategyNames }: DashboardChartProps) =
           <SelectMetricContainer>
             <InputSelect
               options={metricOptions}
-              defaultValue={metricOptions[0]}
+              defaultValue={metricOptions.find((m) => m.value === selectedMetric)}
               onChange={(e) => selectMetric(e.value)}
               isSearchable={false}
             />

--- a/apps/dapp/src/components/Pages/Core/DappPages/Dashboard/Chart/index.tsx
+++ b/apps/dapp/src/components/Pages/Core/DappPages/Dashboard/Chart/index.tsx
@@ -2,10 +2,11 @@ import styled from 'styled-components';
 import { DashboardType } from '../DashboardContent';
 import V2StrategyMetricsChart from './V2StrategyMetricsChart';
 import { InputSelect } from 'components/InputSelect/InputSelect';
-import { V2DailySnapshotMetric } from '../hooks/use-dashboardv2-daily-snapshots';
+import { isV2DailySnapshotMetric, V2DailySnapshotMetric } from '../hooks/use-dashboardv2-daily-snapshots';
 import { useState } from 'react';
 import { ChartSupportedTimeInterval, DEFAULT_CHART_INTERVALS } from 'utils/time-intervals';
 import { IntervalToggler } from 'components/Charts';
+import { useSearchParams } from 'react-router-dom';
 
 type DashboardChartProps = {
   dashboardType: DashboardType;
@@ -26,10 +27,24 @@ const metricOptions: { value: V2DailySnapshotMetric; label: string }[] = [
   { label: 'Nominal Performance', value: 'nominalPerformance' },
 ];
 
+const CHART_SELECTOR_QUERY_PARAM = 'chart';
+
 const DashboardChart = ({ dashboardType, strategyNames }: DashboardChartProps) => {
   console.debug('DashboardChart with dashboardType: ', dashboardType);
-  const [selectedMetric, setSelectedMetric] = useState<V2DailySnapshotMetric>('totalMarketValueUSD');
+
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const defaultMetric: V2DailySnapshotMetric = 'totalMarketValueUSD';
+  const chosenMetric = searchParams.get(CHART_SELECTOR_QUERY_PARAM);
+  const selectedMetric: V2DailySnapshotMetric = isV2DailySnapshotMetric(chosenMetric) ? chosenMetric : defaultMetric;
+
   const [selectedInterval, setSelectedInterval] = useState<ChartSupportedTimeInterval>('1M');
+
+  const selectMetric = (value: string) => {
+    if (isV2DailySnapshotMetric(value)) {
+      setSearchParams({ ...searchParams, [CHART_SELECTOR_QUERY_PARAM]: value });
+    }
+  };
 
   const intervals = DEFAULT_CHART_INTERVALS.filter((i) => ['1W', '1M', '1Y'].includes(i.label));
 
@@ -41,7 +56,7 @@ const DashboardChart = ({ dashboardType, strategyNames }: DashboardChartProps) =
             <InputSelect
               options={metricOptions}
               defaultValue={metricOptions[0]}
-              onChange={(e) => setSelectedMetric(e.value)}
+              onChange={(e) => selectMetric(e.value)}
               isSearchable={false}
             />
           </SelectMetricContainer>

--- a/apps/dapp/src/components/Pages/Core/DappPages/Dashboard/hooks/use-dashboardv2-daily-snapshots.ts
+++ b/apps/dapp/src/components/Pages/Core/DappPages/Dashboard/hooks/use-dashboardv2-daily-snapshots.ts
@@ -3,7 +3,7 @@ import { getQueryKey, useApiQuery } from 'hooks/api/use-react-query';
 import { SubGraphResponse } from 'hooks/core/types';
 import { fetchGenericSubgraph } from 'utils/subgraph';
 
-const V2DailySnapshotMetrics = [
+const V2SnapshotMetrics = [
   'totalMarketValueUSD',
   'debtUSD',
   'netDebtUSD',
@@ -16,29 +16,57 @@ const V2DailySnapshotMetrics = [
   'benchmarkPerformance',
 ] as const;
 
-export type V2DailySnapshotMetric = (typeof V2DailySnapshotMetrics)[number];
+export type V2SnapshotMetric = (typeof V2SnapshotMetrics)[number];
 
-export type V2StrategyDailySnapshot = {
+export type V2StrategySnapshot = {
   timestamp: string;
   timeframe: string;
   strategy: { name: string };
-} & { [key in V2DailySnapshotMetric]: string };
+} & { [key in V2SnapshotMetric]: string };
 
-export function isV2DailySnapshotMetric(key?: string | null): key is V2DailySnapshotMetric {
-  return V2DailySnapshotMetrics.some((m) => m === key);
+export function isV2SnapshotMetric(key?: string | null): key is V2SnapshotMetric {
+  return V2SnapshotMetrics.some((m) => m === key);
 }
 
-type FetchV2StrategyDailySnapshotResponse = SubGraphResponse<{ strategyDailySnapshots: V2StrategyDailySnapshot[] }>;
+type FetchV2StrategyDailySnapshotResponse = SubGraphResponse<{ strategyDailySnapshots: V2StrategySnapshot[] }>;
+type FetchV2StrategyHourlySnapshotResponse = SubGraphResponse<{ strategyHourlySnapshots: V2StrategySnapshot[] }>;
 
+const ONE_DAY_ONE_HOUR_MS = 25 * 60 * 60 * 1000;
 const ONE_YEAR_MS = 365 * 24 * 60 * 60 * 1000;
+
+async function fetchStrategyHourlySnapshots() {
+  const itemsPerPage = 1000;
+  const metrics = V2SnapshotMetrics.join('\n');
+  const now = new Date();
+  const since = Math.floor((now.getTime() - ONE_DAY_ONE_HOUR_MS) / 1000).toString();
+  // if # of strategies * 24 > 1000 we would be missing data
+  // but we shouldnt be getting anywhere close to that
+  const query = `
+            query {
+            strategyHourlySnapshots(first: ${itemsPerPage},
+                                   orderBy: timestamp,
+                                   orderDirection: asc,
+                                   where: {timestamp_gt: ${since}}
+                                   ) {
+                strategy{
+                    name
+                }
+                timeframe
+                timestamp
+                ${metrics}
+            }
+            }`;
+  const resp = await fetchGenericSubgraph<FetchV2StrategyHourlySnapshotResponse>(env.subgraph.templeV2, query);
+  return resp?.data?.strategyHourlySnapshots ?? [];
+}
 
 async function fetchStrategyDailySnapshots() {
   const now = new Date();
   // the largest value from the chart time range selector 1W | 1M | 1Y
   let since = Math.floor((now.getTime() - ONE_YEAR_MS) / 1000).toString();
-  const result: V2StrategyDailySnapshot[] = [];
+  const result: V2StrategySnapshot[] = [];
   const itemsPerPage = 1000; // current max page size
-  const metrics = V2DailySnapshotMetrics.join('\n');
+  const metrics = V2SnapshotMetrics.join('\n');
   while (true) {
     //  we could be missing data with this pagination strategy if
     //  the dataset contain snapshots for different strats
@@ -76,6 +104,21 @@ async function fetchStrategyDailySnapshots() {
   return result;
 }
 
-export default function useV2StrategyDailySnapshotData() {
-  return useApiQuery<V2StrategyDailySnapshot[]>(getQueryKey.allStrategiesDailySnapshots(), fetchStrategyDailySnapshots);
+export default function useV2StrategySnapshotData() {
+  const {
+    data: dailyMetrics,
+    isLoading: dL,
+    isError: dE,
+  } = useApiQuery<V2StrategySnapshot[]>(getQueryKey.allStrategiesDailySnapshots(), fetchStrategyDailySnapshots);
+  const {
+    data: hourlyMetrics,
+    isLoading: hL,
+    isError: hE,
+  } = useApiQuery<V2StrategySnapshot[]>(getQueryKey.allStrategiesHourlySnapshots(), fetchStrategyHourlySnapshots);
+
+  return {
+    dailyMetrics,
+    hourlyMetrics,
+    isLoadingOrError: dL || dE || hL || hE,
+  };
 }

--- a/apps/dapp/src/components/Pages/Core/DappPages/Dashboard/index.tsx
+++ b/apps/dapp/src/components/Pages/Core/DappPages/Dashboard/index.tsx
@@ -1,25 +1,28 @@
-import { Route, Routes, NavLink as BaseNavLink, Navigate } from 'react-router-dom';
+import { Route, Routes, NavLink as BaseNavLink, Navigate, useSearchParams } from 'react-router-dom';
 import styled from 'styled-components';
 import DashboardContent, { DashboardType } from './DashboardContent';
 
 export const DashboardPage = () => {
+  const [searchParams] = useSearchParams();
+  // preserve search params when switching dashboards
+  const params = searchParams.toString();
   return (
     <DashboardContainer>
       <DashboardHeaderNav>
         <NavCell>
-          <NavLink to="treasuryreservesvault">All</NavLink>
+          <NavLink to={`treasuryreservesvault?${params}`}>All</NavLink>
         </NavCell>
         <NavCell>
-          <NavLink to="ramos">RAMOS</NavLink>
+          <NavLink to={`ramos?${params}`}>RAMOS</NavLink>
         </NavCell>
         <NavCell>
-          <NavLink to="tlc">TLC</NavLink>
+          <NavLink to={`tlc?${params}`}>TLC</NavLink>
         </NavCell>
         <NavCell>
-          <NavLink to="templebase">TEMPLE BASE</NavLink>
+          <NavLink to={`templebase?${params}`}>TEMPLE BASE</NavLink>
         </NavCell>
         <NavCell>
-          <NavLink to="dsrbase">DSR BASE</NavLink>
+          <NavLink to={`dsrbase?${params}`}>DSR BASE</NavLink>
         </NavCell>
       </DashboardHeaderNav>
       <DashboardContentContainer>

--- a/apps/dapp/src/hooks/api/use-react-query.ts
+++ b/apps/dapp/src/hooks/api/use-react-query.ts
@@ -9,6 +9,7 @@ export const getQueryKey = {
   metrics: (s?: StrategyKey) => (s ? ['getMetrics', s] : ['getMetrics']),
   trvMetrics: () => ['getTreasureReserveMetrics'],
   allStrategiesDailySnapshots: () => ['strategyDailySnapshots'],
+  allStrategiesHourlySnapshots: () => ['strategyHourlySnapshots'],
 };
 
 const CACHE_TTL = 1000 * 60;


### PR DESCRIPTION
# Description
Store selected chart/metric in url param so we can link to specific dashboards.
Preserves selected option when switching dashboards


https://github.com/TempleDAO/temple/assets/8642344/0eff4ce9-2645-412c-ac9d-deb4a4e750a5



Fixes # (issue)

# Checklist
- [x] Code follows the style guide
- [x] I have performed a self-review of my own code
- [ ] New and existing tests pass locally
- [x] This PR is targeting the correct branch 