### PR TITLE
fix: simplify react-query usage for the transaction table

### DIFF
--- a/apps/dapp/src/hooks/api/use-react-query.ts
+++ b/apps/dapp/src/hooks/api/use-react-query.ts
@@ -4,15 +4,13 @@ import { StrategyKey } from 'components/Pages/Core/DappPages/Dashboard/hooks/use
 // Centralize all the dApp react query keys in case we need to cancel or invalidate them
 // through the app, this makes it easier to track them, please add new ones as required
 export const getQueryKey = {
-  txPagDefault: () => ['getTxPaginationDefaultValues'],
-  txHistory: () => ['getTxHistory'],
   metrics: (s?: StrategyKey) => (s ? ['getMetrics', s] : ['getMetrics']),
   trvMetrics: () => ['getTreasureReserveMetrics'],
   allStrategiesDailySnapshots: () => ['strategyDailySnapshots'],
   allStrategiesHourlySnapshots: () => ['strategyHourlySnapshots'],
 };
 
-const CACHE_TTL = 1000 * 60;
+export const CACHE_TTL = 1000 * 60;
 
 /** useApiQuery: wrapper of useQuery for general dApp configs
  *


### PR DESCRIPTION
Simplifications and improvements for the use of react-query in the transaction table:

* useEffect() calls no longer required to invalidate cache
* cached values are used as you page forward and back through the table
* defining the query key and the query function in the same place improves likelyhood of correctness
* simplify by having useTxHistory work in terms of row offset and limit rather than pages. This saving reexecuting useTxHistoryAvailableRows when the rowsPerPage changes.

untested. example code only