### PR TITLE
fix: sync chart designs with figma

### DIFF
--- a/apps/dapp/src/components/Charts/BiAxialAreaChart.tsx
+++ b/apps/dapp/src/components/Charts/BiAxialAreaChart.tsx
@@ -2,7 +2,7 @@ import type { DataKey } from 'recharts/types/util/types';
 
 import React from 'react';
 import { useTheme } from 'styled-components';
-import { ResponsiveContainer, AreaChart as RechartsChart, Area, XAxis, YAxis, Tooltip, Legend } from 'recharts';
+import { ResponsiveContainer, AreaChart as RechartsChart, Area, XAxis, YAxis, Tooltip, Legend, CartesianGrid } from 'recharts';
 import { formatNumberAbbreviated, formatNumberFixedDecimals } from 'utils/formatter';
 
 type LineChartProps<T> = {
@@ -32,6 +32,7 @@ export default function BiAxialLineChart<T>(props: React.PropsWithChildren<LineC
   return (
     <ResponsiveContainer minHeight={200} minWidth={320} height={400}>
       <RechartsChart data={chartData}>
+        <CartesianGrid horizontal={true} vertical={false} stroke={theme.palette.brandDarker}/>
         {lines.map((line) => (
           <Area
             key={line.series.toString()}
@@ -47,6 +48,8 @@ export default function BiAxialLineChart<T>(props: React.PropsWithChildren<LineC
           />
         ))}
         <XAxis
+          axisLine={false}
+          tickLine={false}
           dataKey={xDataKey}
           label={{ value: xLabel, position: 'bottom', fill: theme.palette.brandLight, offset: -15 }}
           tickFormatter={xTickFormatter}
@@ -54,6 +57,8 @@ export default function BiAxialLineChart<T>(props: React.PropsWithChildren<LineC
           height={50}
         />
         <YAxis
+          axisLine={false}
+          tickLine={false}
           yAxisId="right"
           orientation="right"
           tickFormatter={formatTicker}
@@ -61,6 +66,8 @@ export default function BiAxialLineChart<T>(props: React.PropsWithChildren<LineC
           stroke={lines.find((line) => line.yAxisId === 'right')?.color}
         />
         <YAxis
+          axisLine={false}
+          tickLine={false}
           yAxisId="left"
           orientation="left"
           tickFormatter={formatTicker}

--- a/apps/dapp/src/components/Charts/IntervalToggler.tsx
+++ b/apps/dapp/src/components/Charts/IntervalToggler.tsx
@@ -49,5 +49,6 @@ const Toggle = styled.span<ToggleProps>`
     color: white;
   }
   font-size: 1rem;
+  text-decoration: ${({selected}) => (selected ? 'underline': 'none')};
   font-weight: ${({ selected }) => (selected ? 'bold' : '')};
 `;

--- a/apps/dapp/src/components/Charts/LineChart.tsx
+++ b/apps/dapp/src/components/Charts/LineChart.tsx
@@ -2,7 +2,7 @@ import type { DataKey, AxisDomain } from 'recharts/types/util/types';
 
 import React, { useState } from 'react';
 import { useTheme } from 'styled-components';
-import { ResponsiveContainer, Line, XAxis, YAxis, Tooltip, Legend, ComposedChart, Area } from 'recharts';
+import { CartesianGrid, ResponsiveContainer, Line, XAxis, YAxis, Tooltip, Legend, ComposedChart, Area } from 'recharts';
 import { formatNumberAbbreviated } from 'utils/formatter';
 
 type LineChartProps<T> = {
@@ -61,6 +61,7 @@ export default function LineChart<T>(props: React.PropsWithChildren<LineChartPro
   return (
     <ResponsiveContainer minHeight={200} minWidth={320} height={350}>
       <ComposedChart data={chartData} margin={{ left: 30 }} stackOffset={'sign'}>
+        <CartesianGrid horizontal={true} vertical={false} stroke={theme.palette.brandDarker}/>
         {stackedItems?.map((item) => (
           <Area
             key={item.series}
@@ -86,6 +87,8 @@ export default function LineChart<T>(props: React.PropsWithChildren<LineChartPro
           />
         ))}
         <XAxis
+          axisLine={false}
+          tickLine={false}
           dataKey={xDataKey}
           tickFormatter={xTickFormatter}
           tick={{ stroke: theme.palette.brandLight }}
@@ -93,6 +96,8 @@ export default function LineChart<T>(props: React.PropsWithChildren<LineChartPro
           tickMargin={10}
         />
         <YAxis
+          axisLine={false}
+          tickLine={false}
           tickFormatter={
             yTickFormatter ? (val, i) => yTickFormatter(val, i) : (value) => formatNumberAbbreviated(value).string
           }

--- a/apps/dapp/src/components/Pages/Core/DappPages/Dashboard/Chart/V2StrategyMetricsChart.tsx
+++ b/apps/dapp/src/components/Pages/Core/DappPages/Dashboard/Chart/V2StrategyMetricsChart.tsx
@@ -16,8 +16,8 @@ type XAxisTickFormatter = (timestamp: number) => string;
 const tickFormatters: Record<ChartSupportedTimeInterval, XAxisTickFormatter> = {
   '1D': (timestamp) => format(timestamp, 'h aaa'),
   '1W': (timestamp) => format(timestamp, 'eee d LLL'),
-  '1M': (timestamp) => format(timestamp, 'MMM do'),
-  '1Y': (timestamp) => format(timestamp, 'MMM do y'),
+  '1M': (timestamp) => format(timestamp, 'MMM d'),
+  '1Y': (timestamp) => format(timestamp, 'MMM d y'),
 };
 
 const tooltipLabelFormatters: Record<ChartSupportedTimeInterval, XAxisTickFormatter> = {


### PR DESCRIPTION
# Description
What does this PR solve?
visual changes to the charts (dashboard and main page) in line with https://www.figma.com/file/fZ7bvpavsMdADJjsk7QIsw/Temple-Core?type=design&node-id=7028-9720&mode=design&t=Uo3S0KFODS2ehqz6-0



- remove x and y axis ticks and lines
- add horizontal grid line
- reformat date (oct 23rd -> oct 23)
## before
<img width="1402" alt="Screenshot 2023-11-21 at 10 52 17" src="https://github.com/TempleDAO/temple/assets/8642344/c26b497b-aa9a-4db6-aadb-137e4d317092">
<img width="1093" alt="Screenshot 2023-11-21 at 10 51 59" src="https://github.com/TempleDAO/temple/assets/8642344/6b63a672-99fe-4039-a842-489f2aa2a7c3">
<img width="1159" alt="Screenshot 2023-11-21 at 10 51 51" src="https://github.com/TempleDAO/temple/assets/8642344/e44c9704-adce-410c-bf8d-2c63e882f8ce">


## after
<img width="1043" alt="Screenshot 2023-11-21 at 10 47 01" src="https://github.com/TempleDAO/temple/assets/8642344/4acc17b6-57a5-41ee-ba60-b904896d176a">
<img width="1148" alt="Screenshot 2023-11-21 at 10 46 48" src="https://github.com/TempleDAO/temple/assets/8642344/a9ab07c3-47fc-4c19-b74c-e9b1d28ba31b">
<img width="1408" alt="Screenshot 2023-11-21 at 10 46 36" src="https://github.com/TempleDAO/temple/assets/8642344/42767086-39dc-4095-a611-df1745f3028c">

Fixes # (issue)

# Checklist
- [ ] Code follows the style guide
- [ ] I have performed a self-review of my own code
- [ ] New and existing tests pass locally
- [ ] This PR is targeting the correct branch 