### PR TITLE
fix: split chart tooltip on two lines on mobile

### DIFF
--- a/apps/dapp/src/components/Charts/BiAxialAreaChart.tsx
+++ b/apps/dapp/src/components/Charts/BiAxialAreaChart.tsx
@@ -4,6 +4,8 @@ import React from 'react';
 import { useTheme } from 'styled-components';
 import { ResponsiveContainer, AreaChart as RechartsChart, Area, XAxis, YAxis, Tooltip, Legend, CartesianGrid } from 'recharts';
 import { formatNumberAbbreviated, formatNumberFixedDecimals } from 'utils/formatter';
+import { useMediaQuery } from 'react-responsive';
+import { queryPhone } from 'styles/breakpoints';
 
 type LineChartProps<T> = {
   chartData: T[];
@@ -28,6 +30,9 @@ export default function BiAxialLineChart<T>(props: React.PropsWithChildren<LineC
     xLabel,
   } = props;
   const theme = useTheme();
+  const isDesktop = useMediaQuery({
+    query: queryPhone,
+  });
 
   return (
     <ResponsiveContainer minHeight={200} minWidth={320} height={400}>
@@ -75,6 +80,7 @@ export default function BiAxialLineChart<T>(props: React.PropsWithChildren<LineC
           stroke={lines.find((line) => line.yAxisId === 'left')?.color}
         />
         <Tooltip
+          separator={isDesktop ? ': ' : ':\n  '}
           wrapperStyle={{ outline: 'none', opacity: 0.9 }}
           contentStyle={{
             backgroundColor: theme.palette.dark,
@@ -82,7 +88,11 @@ export default function BiAxialLineChart<T>(props: React.PropsWithChildren<LineC
             borderRadius: '15px',
             border: 0,
           }}
-          itemStyle={{ backgroundColor: theme.palette.dark, color: theme.palette.brandLight }}
+          itemStyle={{
+            backgroundColor: theme.palette.dark,
+            color: theme.palette.brandLight,
+            whiteSpace: 'pre',
+          }}
           labelStyle={{ backgroundColor: theme.palette.dark, fontWeight: 'bold' }}
           labelFormatter={tooltipLabelFormatter}
           formatter={(value, name, _props) => {

--- a/apps/dapp/src/components/Charts/LineChart.tsx
+++ b/apps/dapp/src/components/Charts/LineChart.tsx
@@ -4,6 +4,10 @@ import React, { useState } from 'react';
 import { useTheme } from 'styled-components';
 import { CartesianGrid, ResponsiveContainer, Line, XAxis, YAxis, Tooltip, Legend, ComposedChart, Area } from 'recharts';
 import { formatNumberAbbreviated } from 'utils/formatter';
+import { ContentType, TooltipProps } from 'recharts/types/component/Tooltip';
+import { NameType, ValueType } from 'recharts/types/component/DefaultTooltipContent';
+import { useMediaQuery } from 'react-responsive';
+import { queryPhone } from 'styles/breakpoints';
 
 type LineChartProps<T> = {
   chartData: T[];
@@ -58,6 +62,10 @@ export default function LineChart<T>(props: React.PropsWithChildren<LineChartPro
     }
     setHiddenLines(nextState);
   };
+
+  const isDesktop = useMediaQuery({
+    query: queryPhone,
+  });
   return (
     <ResponsiveContainer minHeight={200} minWidth={320} height={350}>
       <ComposedChart data={chartData} margin={{ left: 30 }} stackOffset={'sign'}>
@@ -107,13 +115,19 @@ export default function LineChart<T>(props: React.PropsWithChildren<LineChartPro
         />
         <Tooltip
           wrapperStyle={{ outline: 'none' }}
+          separator={isDesktop ? ': ' : ':\n  '}
           contentStyle={{
             backgroundColor: theme.palette.dark75,
             color: theme.palette.brand,
             borderRadius: '15px',
             border: 0,
+            minWidth: '180px',
           }}
-          itemStyle={{ backgroundColor: theme.palette.dark75, color: theme.palette.brandLight }}
+          itemStyle={{
+            backgroundColor: theme.palette.dark75,
+            color: theme.palette.brandLight,
+            whiteSpace: 'pre',
+          }}
           labelStyle={{ backgroundColor: theme.palette.dark75, fontWeight: 'bold' }}
           labelFormatter={tooltipLabelFormatter}
           formatter={

--- a/apps/dapp/src/components/Charts/LineChart.tsx
+++ b/apps/dapp/src/components/Charts/LineChart.tsx
@@ -4,8 +4,6 @@ import React, { useState } from 'react';
 import { useTheme } from 'styled-components';
 import { CartesianGrid, ResponsiveContainer, Line, XAxis, YAxis, Tooltip, Legend, ComposedChart, Area } from 'recharts';
 import { formatNumberAbbreviated } from 'utils/formatter';
-import { ContentType, TooltipProps } from 'recharts/types/component/Tooltip';
-import { NameType, ValueType } from 'recharts/types/component/DefaultTooltipContent';
 import { useMediaQuery } from 'react-responsive';
 import { queryPhone } from 'styles/breakpoints';
 

--- a/apps/dapp/src/components/Pages/Core/DappPages/Dashboard/Chart/V2StrategyMetricsChart.tsx
+++ b/apps/dapp/src/components/Pages/Core/DappPages/Dashboard/Chart/V2StrategyMetricsChart.tsx
@@ -71,7 +71,13 @@ const V2StrategyMetricsChart: React.FC<{
   selectedMetric: V2SnapshotMetric;
   selectedInterval: ChartSupportedTimeInterval;
 }> = ({ dashboardType, selectedMetric, selectedInterval, strategyNames }) => {
-  const formatMetricName = (name: string) => `${name} (${selectedMetric.endsWith('Performance') ? '%' : '$'})`;
+  const formatMetricName = (name: string) => `${
+     name
+    // insert a space before all caps
+    .replace(/([A-Z][a-z])/g, ' $1')
+    // uppercase the first character
+    .replace(/^./, str=> str.toUpperCase())
+    .replace(/USD/, '')} ($)`;
 
   const tooltipValuesFormatter = (value: number, name: string) => [
     numberFormatter.format(value),
@@ -111,7 +117,7 @@ const V2StrategyMetricsChart: React.FC<{
       const strategyTokenFormatter = selectedMetric === 'debtUSD' ? (x: string) => parseFloat(x) * -1 : parseFloat;
 
       const strategyTokens = Object.fromEntries(
-        m.strategyTokens.map((t) => [`${selectedMetric}__${t.symbol}`, strategyTokenFormatter(t[strategyTokenMetric])])
+        m.strategyTokens.map((t) => [`${selectedMetric}: ${t.symbol}`, strategyTokenFormatter(t[strategyTokenMetric])])
       );
       return { ...data, ...strategyTokens };
     }

--- a/apps/dapp/src/components/Pages/Core/DappPages/Dashboard/Chart/V2StrategyMetricsChart.tsx
+++ b/apps/dapp/src/components/Pages/Core/DappPages/Dashboard/Chart/V2StrategyMetricsChart.tsx
@@ -63,7 +63,7 @@ const metricFormatters: { [k in V2SnapshotMetric]: MetricFormatter } = {
   totalMarketValueUSD: parseFloat,
 };
 
-const numberFormatter = new Intl.NumberFormat('en', { maximumFractionDigits: 2 });
+const numberFormatter = new Intl.NumberFormat('en', { maximumFractionDigits: 0 });
 
 const V2StrategyMetricsChart: React.FC<{
   dashboardType: DashboardType;
@@ -71,7 +71,7 @@ const V2StrategyMetricsChart: React.FC<{
   selectedMetric: V2SnapshotMetric;
   selectedInterval: ChartSupportedTimeInterval;
 }> = ({ dashboardType, selectedMetric, selectedInterval, strategyNames }) => {
-  const formatMetricName = (name: string) => `${name} (${selectedMetric.endsWith('Performance') ? '%' : 'USD'})`;
+  const formatMetricName = (name: string) => `${name} (${selectedMetric.endsWith('Performance') ? '%' : '$'})`;
 
   const tooltipValuesFormatter = (value: number, name: string) => [
     numberFormatter.format(value),

--- a/apps/dapp/src/components/Pages/Core/DappPages/Dashboard/Chart/V2StrategyMetricsChart.tsx
+++ b/apps/dapp/src/components/Pages/Core/DappPages/Dashboard/Chart/V2StrategyMetricsChart.tsx
@@ -63,7 +63,7 @@ const metricFormatters: { [k in V2SnapshotMetric]: MetricFormatter } = {
   totalMarketValueUSD: parseFloat,
 };
 
-const numberFormatter = new Intl.NumberFormat('en', { maximumFractionDigits: 0 });
+const numberFormatter = new Intl.NumberFormat('en', { maximumFractionDigits: 0, style: 'currency', currency: 'USD' });
 
 const V2StrategyMetricsChart: React.FC<{
   dashboardType: DashboardType;
@@ -71,13 +71,13 @@ const V2StrategyMetricsChart: React.FC<{
   selectedMetric: V2SnapshotMetric;
   selectedInterval: ChartSupportedTimeInterval;
 }> = ({ dashboardType, selectedMetric, selectedInterval, strategyNames }) => {
-  const formatMetricName = (name: string) => `${
-     name
-    // insert a space before all caps
-    .replace(/([A-Z][a-z])/g, ' $1')
-    // uppercase the first character
-    .replace(/^./, str=> str.toUpperCase())
-    .replace(/USD/, '')} ($)`;
+  const formatMetricName = (name: string) =>
+    `${name
+      // insert a space before all caps
+      .replace(/([A-Z][a-z])/g, ' $1')
+      // uppercase the first character
+      .replace(/^./, (str) => str.toUpperCase())
+      .replace(/USD/, '')}`;
 
   const tooltipValuesFormatter = (value: number, name: string) => [
     numberFormatter.format(value),


### PR DESCRIPTION
# Description
Split chart tooltip `metric: value` to two lines when on mobile

Fixes # (issue)

# Checklist
- [ ] Code follows the style guide
- [ ] I have performed a self-review of my own code
- [ ] New and existing tests pass locally
- [ ] This PR is targeting the correct branch 