### PR TITLE
Limit geoblocked users to legacy withdraw page

### DIFF
--- a/apps/dapp/src/components/Layouts/CoreLayout/Account.tsx
+++ b/apps/dapp/src/components/Layouts/CoreLayout/Account.tsx
@@ -21,14 +21,9 @@ export const Account = () => {
   const isSmallDesktop = useMediaQuery({
     query: queryVerySmallDesktop,
   });
-  const { isBlocked } = useGeoBlocked();
 
   if (connecting) {
     return <Loader />;
-  }
-
-  if (isBlocked) {
-    return <ConnectButton disabled label="Restricted Jurisdiction" isSmall isActive isUppercase role="button" />;
   }
 
   if (wallet) {

--- a/apps/dapp/src/components/Layouts/V2Layout/Nav/WalletNav.tsx
+++ b/apps/dapp/src/components/Layouts/V2Layout/Nav/WalletNav.tsx
@@ -15,7 +15,6 @@ import { useState } from 'react';
 import { useConnectWallet, useSetChain } from '@web3-onboard/react';
 import { useWallet } from 'providers/WalletProvider';
 import TruncatedAddress from 'components/TruncatedAddress';
-import { useGeoBlocked } from 'hooks/use-geo-blocked';
 
 type WalletNavProps = {
   isNavCollapsed: boolean;
@@ -26,7 +25,6 @@ export const WalletNav = (props: WalletNavProps) => {
   const { isNavCollapsed, onClickHandler } = props;
   const [{ wallet, connecting }, connect, disconnect] = useConnectWallet();
   const { walletAddress } = useWallet();
-  const { isBlocked } = useGeoBlocked();
 
   const [isWalletDropdownOpen, setIsWalletDropdownOpen] = useState(false);
   const [{ connectedChain }] = useSetChain();
@@ -46,8 +44,6 @@ export const WalletNav = (props: WalletNavProps) => {
   const explorerUrl = getChainExplorerURL(walletAddress || '', currentChainId);
 
   const connectWallet = async () => {
-    // TODO: What to do in this case?
-    if (isBlocked) return alert('Restricted Jurisdiction');
     if (onClickHandler) onClickHandler();
     await connect();
   };
@@ -60,7 +56,7 @@ export const WalletNav = (props: WalletNavProps) => {
   return (
     <WalletContainer onMouseLeave={() => setIsWalletDropdownOpen(false)}>
       {connecting && <Loader iconSize={24} />}
-      {!connecting && !isBlocked && wallet ? (
+      {!connecting && wallet ? (
         <FlexColumnContainer>
           <WalletConnectedContainer onClick={() => setIsWalletDropdownOpen(!isWalletDropdownOpen)}>
             <WalletIcon />
@@ -91,12 +87,6 @@ export const WalletNav = (props: WalletNavProps) => {
           <WalletIcon fill={theme.palette.light} />
           {!isNavCollapsed && <NavLinkText style={{ cursor: 'pointer' }}>Connect</NavLinkText>}
         </div>
-      )}
-      {!connecting && isBlocked && (
-        <>
-          <WalletIcon fill={theme.palette.grayOpaque} />
-          {!isNavCollapsed && <NavLinkText small>Blocked</NavLinkText>}
-        </>
       )}
     </WalletContainer>
   );

--- a/apps/dapp/src/components/Layouts/V2Layout/V2Account.tsx
+++ b/apps/dapp/src/components/Layouts/V2Layout/V2Account.tsx
@@ -18,19 +18,13 @@ export const V2Account = () => {
   const { walletAddress } = useWallet();
   const [{ connectedChain }] = useSetChain();
   const currentChainId = useMemo(() => parseInt(connectedChain?.id || '', 16), [connectedChain]);
-  const { isBlocked } = useGeoBlocked();
 
   const isSmallDesktop = useMediaQuery({
     query: queryVerySmallDesktop,
   });
 
-
   if (connecting) {
     return <Loader />;
-  }
-
-  if (isBlocked) {
-    return <ConnectButton disabled label="Restricted Jurisdiction" isSmall isActive isUppercase role="button" />;
   }
 
   if (wallet) {

--- a/apps/dapp/src/components/Layouts/V2Layout/index.tsx
+++ b/apps/dapp/src/components/Layouts/V2Layout/index.tsx
@@ -1,7 +1,7 @@
-import { FunctionComponent, SVGProps, useState } from 'react';
+import { FunctionComponent, SVGProps, useEffect, useState } from 'react';
 import * as breakpoints from 'styles/breakpoints';
 import { useMediaQuery } from 'react-responsive';
-import { Outlet, useLocation } from 'react-router-dom';
+import { Outlet, useLocation, useNavigate } from 'react-router-dom';
 
 import styled from 'styled-components';
 import { queryMinTablet } from 'styles/breakpoints';
@@ -14,6 +14,7 @@ import CurrencyExchange from 'assets/icons/currency_exchange.svg?react';
 import Payments from 'assets/icons/payments.svg?react';
 import Candle from 'assets/icons/candle.svg?react';
 import Restore from 'assets/icons/restore.svg?react';
+import { useGeoBlocked } from 'hooks/use-geo-blocked';
 
 export type MenuNavItem = {
   label: string;
@@ -37,6 +38,8 @@ const V2Layout = () => {
     query: queryMinTablet,
   });
   const loc = useLocation();
+  const navigate = useNavigate();
+  const { isBlocked, loading } = useGeoBlocked();
   const [menuNavItems, setMenuNavItems] = useState<Array<MenuNavItem>>([
     {
       label: 'Trade',
@@ -70,6 +73,18 @@ const V2Layout = () => {
       selected: V2DashboardLocPaths.Legacy === loc.pathname,
     },
   ]);
+
+  // Handle geoblocked users
+  useEffect(() => {
+    // Define all permitted paths
+    const permittedPaths = ['/dapp/legacy'];
+    if (loading || (!loading && !isBlocked)) return;
+    // Force redirect to permitted path
+    if (!permittedPaths.find((path) => path === loc.pathname)) navigate(permittedPaths[0]);
+    // Remove nav items that are not permitted
+    const newMenuNavItems = menuNavItems.filter((menuItem) => permittedPaths.find((path) => path === menuItem.linkTo));
+    setMenuNavItems(newMenuNavItems);
+  }, [loading, isBlocked, loc]);
 
   const onSelectMenuNavItems = async (selectedMenuItem: MenuNavItem) => {
     await setMenuNavItems((prevSelectedMenuNavItems) => {

--- a/apps/dapp/src/components/Pages/Core/DappPages/Legacy/ClaimFromVaults.tsx
+++ b/apps/dapp/src/components/Pages/Core/DappPages/Legacy/ClaimFromVaults.tsx
@@ -10,6 +10,8 @@ import { VaultButton } from '../../VaultPages/VaultContent';
 import { useTokenContractAllowance } from 'hooks/core/use-token-contract-allowance';
 import env from 'constants/env';
 import _ from 'lodash';
+import { useConnectWallet } from '@web3-onboard/react';
+import { TradeButton } from '../../NewUI/Home';
 
 const EMPTY_CLAIM_STATE = {
   claimSubvaultAddress: '',
@@ -17,6 +19,7 @@ const EMPTY_CLAIM_STATE = {
 };
 
 export const ClaimFromVaults = () => {
+  const [{ wallet }, connect] = useConnectWallet();
   const {
     balances: { balances, isLoading: balancesIsLoading },
     vaultGroups: { vaultGroups, isLoading: vaultGroupsIsLoading },
@@ -103,7 +106,14 @@ export const ClaimFromVaults = () => {
       )}
 
       <ButtonContainer>
-        {Number(claimState.claimAmount) === 0 ? (
+        {!wallet ? (
+          <TradeButton
+            label={`Connect`}
+            onClick={() => {
+              connect();
+            }}
+          />
+        ) : Number(claimState.claimAmount) === 0 ? (
           <ClaimButton
             label={`Nothing to Claim`}
             disabled={true}

--- a/apps/dapp/src/components/Pages/Core/DappPages/Legacy/UnstakeOGT.tsx
+++ b/apps/dapp/src/components/Pages/Core/DappPages/Legacy/UnstakeOGT.tsx
@@ -8,8 +8,11 @@ import { formatBigNumber, formatTemple, getBigNumberFromString } from 'component
 import { ZERO } from 'utils/bigNumber';
 import { useStaking } from 'providers/StakingProvider';
 import { BigNumber } from 'ethers';
+import { useConnectWallet } from '@web3-onboard/react';
+import { TradeButton } from '../../NewUI/Home';
 
 export const UnstakeOGT = () => {
+  const [{}, connect] = useConnectWallet();
   const { wallet, signer, balance, updateBalance } = useWallet();
   const [_, refreshWallet] = useRefreshWalletState();
   const [unstakeAmount, setUnstakeAmount] = useState<string>('');
@@ -54,14 +57,24 @@ export const UnstakeOGT = () => {
       {lockedEntries.length > 0 ? (
         <>
           <TopSubtitle>You can claim locked OGTemple from the Opening Ceremony:</TopSubtitle>
-          <ClaimButton
-            isSmall
-            onClick={() => handleUnlockOGT()}
-            disabled={Date.now() < lockedEntries[0].lockedUntilTimestamp}
-          >
-            Claim {formatTemple(lockedEntries.reduce((sum, cur) => sum.add(cur.balanceOGTemple), BigNumber.from('0')))}{' '}
-            OGTemple
-          </ClaimButton>
+          {!wallet ? (
+            <TradeButton
+              label={`Connect`}
+              onClick={() => {
+                connect();
+              }}
+            />
+          ) : (
+            <TradeButton
+              isSmall
+              onClick={() => handleUnlockOGT()}
+              disabled={Date.now() < lockedEntries[0].lockedUntilTimestamp}
+            >
+              Claim{' '}
+              {formatTemple(lockedEntries.reduce((sum, cur) => sum.add(cur.balanceOGTemple), BigNumber.from('0')))}{' '}
+              OGTemple
+            </TradeButton>
+          )}
           <Subtitle>
             {lockedEntries.length > 1 && (
               <span>
@@ -80,9 +93,18 @@ export const UnstakeOGT = () => {
             TEMPLE.
           </Subtitle>
           <ButtonContainer>
-            <ClaimButton disabled={buttonIsDisabled} onClick={() => unstake(unstakeAmount)}>
-              Unstake OGTEMPLE
-            </ClaimButton>
+            {!wallet ? (
+              <TradeButton
+                label={`Connect`}
+                onClick={() => {
+                  connect();
+                }}
+              />
+            ) : (
+              <TradeButton disabled={buttonIsDisabled} onClick={() => unstake(unstakeAmount)}>
+                Unstake OGTEMPLE
+              </TradeButton>
+            )}
           </ButtonContainer>
         </>
       )}

--- a/apps/dapp/src/components/Pages/Core/NewUI/TradeNew.tsx
+++ b/apps/dapp/src/components/Pages/Core/NewUI/TradeNew.tsx
@@ -13,6 +13,7 @@ import { useEffect } from 'react';
 import { useNotification } from 'providers/NotificationProvider';
 import { TransactionPreviewModal } from 'components/TransactionSettingsModal/TransactionPreviewModal';
 import { tabletAndAbove } from 'styles/breakpoints';
+import { useConnectWallet } from '@web3-onboard/react';
 
 export const Trade = () => {
   const {
@@ -25,6 +26,7 @@ export const Trade = () => {
     handleTransaction,
   } = useSwapController();
 
+  const [{ wallet }, connect] = useConnectWallet();
   const [isPreviewModalOpen, setIsPreviewModalOpen] = useState(false);
   const [isSlippageModalOpen, setIsSlippageModalOpen] = useState(false);
 
@@ -98,11 +100,20 @@ export const Trade = () => {
           <AdvancedSettingsButton onClick={() => setIsSlippageModalOpen(true)}>
             Advanced Settings
           </AdvancedSettingsButton>
-          <TradeButton
-            disabled={!state.quote || state.quote.returnAmount.lte(0)}
-            label="Preview"
-            onClick={() => setIsPreviewModalOpen(true)}
-          />
+          {!wallet ? (
+            <TradeButton
+              label={`Connect`}
+              onClick={() => {
+                connect();
+              }}
+            />
+          ) : (
+            <TradeButton
+              disabled={!state.quote || state.quote.returnAmount.lte(0)}
+              label="Preview"
+              onClick={() => setIsPreviewModalOpen(true)}
+            />
+          )}
         </ButtonContainer>
       </SwapContainer>
     </TradeContainer>

--- a/apps/dapp/src/hooks/use-geo-blocked.tsx
+++ b/apps/dapp/src/hooks/use-geo-blocked.tsx
@@ -2,7 +2,8 @@ import { useEffect, useState } from 'react';
 
 export const useGeoBlocked = () => {
   const [isBlocked, setIsBlocked] = useState(false);
-  
+  const [loading, setLoading] = useState(true);
+
   useEffect(() => {
     const checkBlocked = async () => {
       const blocked = await fetch(`${window.location.href}api/geoblock`)
@@ -10,11 +11,13 @@ export const useGeoBlocked = () => {
         .then((res) => res.blocked)
         .catch(() => false);
       setIsBlocked(blocked);
+      setLoading(false);
     };
     checkBlocked();
   }, []);
 
   return {
     isBlocked,
+    loading,
   };
 };

--- a/apps/dapp/src/providers/WalletProvider.tsx
+++ b/apps/dapp/src/providers/WalletProvider.tsx
@@ -66,6 +66,8 @@ export const WalletProvider = (props: PropsWithChildren<object>) => {
       } else {
         setWalletAddress(undefined);
       }
+    } else {
+      setWalletAddress(undefined);
     }
   }, [wallet, connecting]);
 


### PR DESCRIPTION
# Description
Instead of preventing geoblocked users from connecting their wallet, this PR intends to limit which pages are accessible, so that only the legacy withdraw functionality is permitted. 

# Checklist
- [x] Code follows the style guide
- [x] I have performed a self-review of my own code
- [x] New and existing tests pass locally
- [x] This PR is targeting the correct branch 