### PR TITLE
fix: vault claim approval rounding err

### DIFF
--- a/apps/dapp/src/components/Pages/Core/DappPages/Legacy/ClaimFromVaults.tsx
+++ b/apps/dapp/src/components/Pages/Core/DappPages/Legacy/ClaimFromVaults.tsx
@@ -2,7 +2,7 @@ import styled from 'styled-components';
 import { useVaultContext } from '../../VaultContext';
 import { formatBigNumber, formatTemple, getBigNumberFromString } from 'components/Vault/utils';
 import { ZERO } from 'utils/bigNumber';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { Vault, VaultGroup } from 'components/Vault/types';
 import { BigNumber, ethers } from 'ethers';
 import { useWithdrawFromVault } from 'hooks/core/use-withdraw-from-vault';
@@ -122,7 +122,10 @@ export const ClaimFromVaults = () => {
     });
   };
 
-  const insufficientAllowance = allowance.lt(getBigNumberFromString(claimState.claimAmount));
+  const insufficientAllowance = useMemo(
+    () => allowance.lt(getBigNumberFromString(claimState.claimAmount)),
+    [allowance, claimState.claimAmount]
+  );
 
   return (
     <ClaimContainer>


### PR DESCRIPTION
# Description
1/ changed the approval from the exact subvault balance to MaxUint256 (we were losing decimal place precision before)
2/ stopped using the wagmi allowance hook in exchange for a more verbose ethers approval flow. basically the same approval flow from Ohmage OTC, which could eventually be abstracted

# Checklist
- [x] Code follows the style guide
- [x] I have performed a self-review of my own code
- [x] New and existing tests pass locally
- [x] This PR is targeting the correct branch 