### PR TITLE
Use Ramos subgraph to get Temple spot price

### DIFF
--- a/apps/dapp/src/components/Pages/Core/DappPages/Dashboard/hooks/use-dashboardv2-metrics.ts
+++ b/apps/dapp/src/components/Pages/Core/DappPages/Dashboard/hooks/use-dashboardv2-metrics.ts
@@ -288,19 +288,17 @@ export default function useDashboardV2Metrics(dashboardType: DashboardType) {
 
   const getTempleSpotPrice = async () => {
     const response = await fetchGenericSubgraph<any>(
-      env.subgraph.templeV2,
+      env.subgraph.ramos,
       `{
-          tokens {
-             name
-             price
-           }
+        metrics {
+          spotPrice
+        }
       }`
     );
 
-    const tokenData = response?.data?.tokens;
+    const data = response?.data?.metrics?.[0] || {};
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    return tokenData.find((token: any) => token.name === 'Temple')?.price;
+    return data.spotPrice;
   };
 
   const formatPercent = (input: number) => {


### PR DESCRIPTION
# Description
Due to recent changes to the v2 subgraph, we have to get the Temple spot price from the Ramos subgraph.

# Checklist
- [x] Code follows the style guide
- [x] I have performed a self-review of my own code
- [x] New and existing tests pass locally
- [x] This PR is targeting the correct branch 