### PR TITLE
chore: Refactor dashboard configuration to one place

### DIFF
--- a/apps/dapp/src/components/Pages/Core/DappPages/Dashboard/Chart/index.tsx
+++ b/apps/dapp/src/components/Pages/Core/DappPages/Dashboard/Chart/index.tsx
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 import * as breakpoints from 'styles/breakpoints';
-import { DashboardType } from '../DashboardContent';
+import { DashboardData } from '../DashboardConfig';
 import V2StrategyMetricsChart from './V2StrategyMetricsChart';
 import { InputSelect } from 'components/InputSelect/InputSelect';
 import { isV2SnapshotMetric, V2SnapshotMetric } from '../hooks/use-dashboardv2-daily-snapshots';
@@ -11,8 +11,7 @@ import { useSearchParams } from 'react-router-dom';
 import { useMediaQuery } from 'react-responsive';
 
 type DashboardChartProps = {
-  dashboardType: DashboardType;
-  strategyNames: string[];
+  dashboardData: DashboardData;
 };
 
 const metricOptions: { value: V2SnapshotMetric; label: string }[] = [
@@ -28,8 +27,8 @@ const metricOptions: { value: V2SnapshotMetric; label: string }[] = [
 
 const CHART_SELECTOR_QUERY_PARAM = 'chart';
 
-const DashboardChart = ({ dashboardType, strategyNames }: DashboardChartProps) => {
-  console.debug('DashboardChart with dashboardType: ', dashboardType);
+const DashboardChart = ({ dashboardData }: DashboardChartProps) => {
+  console.debug('DashboardChart with name: ', dashboardData.name);
 
   const [searchParams, setSearchParams] = useSearchParams();
   const isDesktop = useMediaQuery({
@@ -66,10 +65,9 @@ const DashboardChart = ({ dashboardType, strategyNames }: DashboardChartProps) =
           </IntervalTogglerContainer>
         </ChartHeader>
         <V2StrategyMetricsChart
-          dashboardType={dashboardType}
+          dashboardData={dashboardData}
           selectedMetric={selectedMetric}
           selectedInterval={selectedInterval}
-          strategyNames={strategyNames}
         />
       </ChartContainer>
     </>

--- a/apps/dapp/src/components/Pages/Core/DappPages/Dashboard/DashboardConfig.tsx
+++ b/apps/dapp/src/components/Pages/Core/DappPages/Dashboard/DashboardConfig.tsx
@@ -1,0 +1,97 @@
+import env from 'constants/env';
+
+/*
+ Note that the StrategyKey matches what's in the contracts
+ https://github.com/TempleDAO/temple/blob/stage/protocol/contracts/interfaces/v2/strategies/ITempleStrategy.sol#L57
+*/
+export enum StrategyKey {
+  RAMOS = 'RamosStrategy',
+  // TLC = 'TlcStrategy',
+  TEMPLEBASE = 'TempleBaseStrategy',
+  DSRBASE = 'DsrBaseStrategy',
+  TEMPLO_MAYOR_GNOSIS = 'TemploMayorStrategy',
+  FOHMO_GNOSIS = 'FohmoStrategy',
+}
+
+// Except this special case for the Treasury Reserves Vault dashboard
+export const TRV_KEY = 'TreasuryReservesVault';
+export type TrvKey = typeof TRV_KEY;
+
+export const ALL_STRATEGIES = Object.values(StrategyKey);
+
+export const isTRVDashboard = (strategy: StrategyKey | TrvKey) => strategy === TRV_KEY;
+
+export type DashboardData = {
+  key: StrategyKey | TrvKey;
+  name: string;
+  title: string;
+  path: string;
+  description: string;
+  contractLink: string;
+};
+
+export const Dashboards: DashboardData[] = [
+  {
+    key: TRV_KEY,
+    name: 'Treasury Reserves Vault',
+    title: 'TRV',
+    path: 'treasuryreservesvault',
+    description:
+      'Treasury Reserves Vault (TRV) coordinates and manages the flow of capital for current Treasury allocations. When funding and management parameters are approved for a Strategy, the TRV will transfer funds e.g. DAI and issue corresponding debt to the Strategy borrower. The current equity of the Strategy is discounted by the loan principal and accrued interest benchmarked to the prevailing rate of the current Base Strategy for the borrowed token.',
+    contractLink: `${env.etherscan}/address/${env.contracts.treasuryReservesVault}`,
+  },
+  {
+    key: StrategyKey.RAMOS,
+    name: 'Ramos',
+    title: 'RAMOS',
+    path: 'ramos',
+    description:
+      'Ramos is the automated market operations (AMO) manager that supplies liquidity to the TEMPLE/DAI pool on the Balancer Exchange platform. A bot manages the contract to support TEMPLE trading, reduce price volatility, and earn farming rewards.',
+    contractLink: `${env.etherscan}/address/${env.contracts.strategies.ramosStrategy}`,
+  },
+  //   { // TODO: Hidden until launch
+  // key: DashboardKey.TLC,
+  // name: 'TLC',
+  // title: 'TLC',
+  // path: 'tlc',
+  // description:
+  //   'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque vehicula tincidunt eleifend. Nam congue magna in mi dignissim, id gravida sem ornare. Sed in nunc fermentum, consectetur ipsum a, varius augue. Nullam finibus velit eget ligula efficitur, in luctus lacus efficitur. Nam egestas tempor gravida. Ut mollis libero ac tincidunt fermentum. Etiam et ante vitae metus ultrices tempus.',
+  // contractLink: `${env.etherscan}/address/${env.contracts.strategies.tlcStrategy}`,
+  //   },
+  {
+    key: StrategyKey.TEMPLEBASE,
+    name: 'Temple Base',
+    title: 'TEMPLE BASE',
+    path: 'templebase',
+    description:
+      'Temple Base strategy is the source of automated market operations (AMO) TEMPLE tokens in the Treasury framework. The TRV facilitates the withdrawal of newly minted TEMPLE tokens from and the issuance of TEMPLE debt to the Temple Base strategy. These TEMPLE tokens will be borrowed by a Treasury Strategy such as Ramos to generate returns. Once these tokens are repaid to the TRV, they will be deposited to the Temple Base strategy to be burned. From the perspective of the TRV, positive returns will be realized when TEMPLE flows to the Temple Base strategy is net positive.',
+    contractLink: `${env.etherscan}/address/${env.contracts.strategies.templeStrategy}`,
+  },
+  {
+    key: StrategyKey.DSRBASE,
+    name: 'DSR Base',
+    title: 'DSR BASE',
+    path: 'dsrbase',
+    description:
+      'Idle capital in the Treasury Reserves Vault (TRV) that is not currently deployed to a Strategy borrower will be automatically directed to a Base Strategy to earn yield. Currently, the Base Strategy is set to the Dai Savings Rate (DSR) which makes DAI the base currency of the TRV. The current rate of return for DSR Base also serves as the benchmark interest rate for the Treasury Strategy that borrows DAI from the TRV.',
+    contractLink: `${env.etherscan}/address/${env.contracts.strategies.dsrBaseStrategy}`,
+  },
+  {
+    key: StrategyKey.TEMPLO_MAYOR_GNOSIS,
+    name: 'Templo Mayor',
+    title: 'TEMPLO MAYOR',
+    path: 'templomayor',
+    description:
+      'Templo Mayor is an Gnosis Safe Omnibus strategy. An Omnibus Strategy utilises the same bookkeeping structure and approval process, but may entail several related holdings or sub-positions that are managed as a whole. For instance, deposits into different but similar or co-dependent vaults on the same platform or different platforms may be consolidated into one Omnibus Gnosis Safe. Seed allocations of a target risk profile may also be consolidated into an Omnibus Strategy to reduce the noise. Therefore an Omnibus Strategy may provide additional operational efficiency and allow Stakeholders to evaluate a series of related deployments as one composite position rather than as singletons.',
+    contractLink: `${env.etherscan}/address/${env.contracts.strategies.temploMayorGnosisStrategy}`,
+  },
+  {
+    key: StrategyKey.FOHMO_GNOSIS,
+    name: 'Fohmo',
+    title: 'FOHMO',
+    path: 'fohmo',
+    description:
+      'FOHMO is a Gnosis Safe that holds the governance tokens for the DSR ecosystem. It is the primary point of interaction for the governance of the DSR ecosystem.',
+    contractLink: `${env.etherscan}/address/${env.contracts.strategies.fohmoGnosisStrategy}`,
+  },
+];

--- a/apps/dapp/src/components/Pages/Core/DappPages/Dashboard/DashboardConfig.tsx
+++ b/apps/dapp/src/components/Pages/Core/DappPages/Dashboard/DashboardConfig.tsx
@@ -6,7 +6,7 @@ import env from 'constants/env';
 */
 export enum StrategyKey {
   RAMOS = 'RamosStrategy',
-  // TLC = 'TlcStrategy',
+  TLC = 'TlcStrategy',
   TEMPLEBASE = 'TempleBaseStrategy',
   DSRBASE = 'DsrBaseStrategy',
   TEMPLO_MAYOR_GNOSIS = 'TemploMayorStrategy',
@@ -49,15 +49,15 @@ export const Dashboards: DashboardData[] = [
       'Ramos is the automated market operations (AMO) manager that supplies liquidity to the TEMPLE/DAI pool on the Balancer Exchange platform. A bot manages the contract to support TEMPLE trading, reduce price volatility, and earn farming rewards.',
     contractLink: `${env.etherscan}/address/${env.contracts.strategies.ramosStrategy}`,
   },
-  //   { // TODO: Hidden until launch
-  // key: DashboardKey.TLC,
-  // name: 'TLC',
-  // title: 'TLC',
-  // path: 'tlc',
-  // description:
-  //   'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque vehicula tincidunt eleifend. Nam congue magna in mi dignissim, id gravida sem ornare. Sed in nunc fermentum, consectetur ipsum a, varius augue. Nullam finibus velit eget ligula efficitur, in luctus lacus efficitur. Nam egestas tempor gravida. Ut mollis libero ac tincidunt fermentum. Etiam et ante vitae metus ultrices tempus.',
-  // contractLink: `${env.etherscan}/address/${env.contracts.strategies.tlcStrategy}`,
-  //   },
+  {
+    key: StrategyKey.TLC,
+    name: 'TLC',
+    title: 'TLC',
+    path: 'tlc',
+    description:
+      'Temple Loving Care (also known as Temple Line of Credit) offers DAI lending for users who supply TEMPLE token as collateral. The value of the collateral is not determined by the current $TEMPLE spot price on the Balancer DEX but by the current Treasury Price Index (TPI). Users may borrow up to 75% loan-to-value (LTV) with the liquidation LTV set to 80%. There are no origination fees and users can withdraw their collateral at any time by repaying the DAI loan. TLC interest rate is a variable APR that is dependent on Debt Ceiling Utilisation. Any accrued interest will increase LTV over time. Borrowers can expect the APR to be set no lower than the prevailing APR for the Treasury DAI Base Strategy. <a target="_blank" href="https://templedao.medium.com/he-who-controls-the-spice-controls-the-universe-bae5fb92bd43">Click here</a> to learn more about Temple Loving Care.',
+    contractLink: `${env.etherscan}/address/${env.contracts.strategies.tlcStrategy}`,
+  },
   {
     key: StrategyKey.TEMPLEBASE,
     name: 'Temple Base',

--- a/apps/dapp/src/components/Pages/Core/DappPages/Dashboard/DashboardContent.tsx
+++ b/apps/dapp/src/components/Pages/Core/DappPages/Dashboard/DashboardContent.tsx
@@ -1,107 +1,31 @@
 import styled from 'styled-components';
 import * as breakpoints from 'styles/breakpoints';
 import DashboardChart from './Chart';
-import { StrategyKey } from './hooks/use-dashboardv2-metrics';
 import DashboardMetrics from './Metrics';
 import DashboardTransactionHistory from './Table';
 import linkSvg from 'assets/icons/link.svg?react';
-import env from 'constants/env';
-
-export enum DashboardType {
-  TREASURY_RESERVES_VAULT,
-  RAMOS,
-  TLC,
-  TEMPLE_BASE,
-  DSR_BASE,
-  TEMPLO_MAYOR_GNOSIS,
-  FOHMO_GNOSIS,
-}
+import {DashboardData, Dashboards} from './DashboardConfig';
 
 type DashboardContentProps = {
-  selectedDashboard?: DashboardType;
+  selectedDashboard?: DashboardData;
 };
 
-type DashboardData = {
-  [key in DashboardType]: {
-    title: string;
-    description: string;
-    chartStrategyNames: StrategyKey[];
-    link: string;
-  };
-};
+const DEFAULT_DASHBOARD = Dashboards[0];
 
-const DashboardContent = ({ selectedDashboard = DashboardType.TREASURY_RESERVES_VAULT }: DashboardContentProps) => {
-  const dashboardData: DashboardData = {
-    [DashboardType.TREASURY_RESERVES_VAULT]: {
-      title: 'Treasury Reserves Vault',
-      description:
-        'Treasury Reserves Vault (TRV) coordinates and manages the flow of capital for current Treasury allocations. When funding and management parameters are approved for a Strategy, the TRV will transfer funds e.g. DAI and issue corresponding debt to the Strategy borrower. The current equity of the Strategy is discounted by the loan principal and accrued interest benchmarked to the prevailing rate of the current Base Strategy for the borrowed token.',
-      chartStrategyNames: [
-        StrategyKey.TEMPLEBASE,
-        StrategyKey.RAMOS,
-        StrategyKey.DSRBASE,
-        StrategyKey.TEMPLO_MAYOR_GNOSIS,
-        StrategyKey.FOHMO_GNOSIS,
-      ],
-      link: `${env.etherscan}/address/${env.contracts.treasuryReservesVault}`,
-    },
-    [DashboardType.RAMOS]: {
-      title: 'Ramos',
-      description:
-        'Ramos is the automated market operations (AMO) manager that supplies liquidity to the TEMPLE/DAI pool on the Balancer Exchange platform. A bot manages the contract to support TEMPLE trading, reduce price volatility, and earn farming rewards.',
-      chartStrategyNames: [StrategyKey.RAMOS],
-      link: `${env.etherscan}/address/${env.contracts.strategies.ramosStrategy}`,
-    },
-    [DashboardType.TLC]: {
-      title: 'TLC',
-      description:
-        'Temple Loving Care (also known as Temple Line of Credit) offers DAI lending for users who supply TEMPLE token as collateral. The value of the collateral is not determined by the current $TEMPLE spot price on the Balancer DEX but by the current Treasury Price Index (TPI). Users may borrow up to 75% loan-to-value (LTV) with the liquidation LTV set to 80%. There are no origination fees and users can withdraw their collateral at any time by repaying the DAI loan. TLC interest rate is a variable APR that is dependent on Debt Ceiling Utilisation. Any accrued interest will increase LTV over time. Borrowers can expect the APR to be set no lower than the prevailing APR for the Treasury DAI Base Strategy. <a target="_blank" href="https://templedao.medium.com/he-who-controls-the-spice-controls-the-universe-bae5fb92bd43">Click here</a> to learn more about Temple Loving Care.',
-      chartStrategyNames: [StrategyKey.TLC],
-      link: `${env.etherscan}/address/${env.contracts.strategies.tlcStrategy}`,
-    },
-    [DashboardType.TEMPLE_BASE]: {
-      title: 'Temple Base',
-      description:
-        'Temple Base strategy is the source of automated market operations (AMO) TEMPLE tokens in the Treasury framework. The TRV facilitates the withdrawal of newly minted TEMPLE tokens from and the issuance of TEMPLE debt to the Temple Base strategy. These TEMPLE tokens will be borrowed by a Treasury Strategy such as Ramos to generate returns. Once these tokens are repaid to the TRV, they will be deposited to the Temple Base strategy to be burned. From the perspective of the TRV, positive returns will be realized when TEMPLE flows to the Temple Base strategy is net positive.',
-      chartStrategyNames: [StrategyKey.TEMPLEBASE],
-      link: `${env.etherscan}/address/${env.contracts.strategies.templeStrategy}`,
-    },
-    [DashboardType.DSR_BASE]: {
-      title: 'DSR Base',
-      description:
-        'Idle capital in the Treasury Reserves Vault (TRV) that is not currently deployed to a Strategy borrower will be automatically directed to a Base Strategy to earn yield. Currently, the Base Strategy is set to the Dai Savings Rate (DSR) which makes DAI the base currency of the TRV. The current rate of return for DSR Base also serves as the benchmark interest rate for the Treasury Strategy that borrows DAI from the TRV.',
-      chartStrategyNames: [StrategyKey.DSRBASE],
-      link: `${env.etherscan}/address/${env.contracts.strategies.dsrBaseStrategy}`,
-    },
-    [DashboardType.TEMPLO_MAYOR_GNOSIS]: {
-      title: 'Templo Mayor',
-      description:
-        'Templo Mayor is an Gnosis Safe Omnibus strategy. An Omnibus Strategy utilises the same bookkeeping structure and approval process, but may entail several related holdings or sub-positions that are managed as a whole. For instance, deposits into different but similar or co-dependent vaults on the same platform or different platforms may be consolidated into one Omnibus Gnosis Safe. Seed allocations of a target risk profile may also be consolidated into an Omnibus Strategy to reduce the noise. Therefore an Omnibus Strategy may provide additional operational efficiency and allow Stakeholders to evaluate a series of related deployments as one composite position rather than as singletons.',
-      chartStrategyNames: [StrategyKey.TEMPLO_MAYOR_GNOSIS],
-      link: `${env.etherscan}/address/${env.contracts.strategies.temploMayorGnosisStrategy}`,
-    },
-    [DashboardType.FOHMO_GNOSIS]: {
-      title: 'Fohmo',
-      description: '',
-      chartStrategyNames: [StrategyKey.FOHMO_GNOSIS],
-      link: `${env.etherscan}/address/${env.contracts.strategies.fohmoGnosisStrategy}`,
-    },
-  };
-
-  const dashboard = dashboardData[selectedDashboard];
+const DashboardContent = ({ selectedDashboard = DEFAULT_DASHBOARD }: DashboardContentProps) => {
 
   return (
     <DashboardContentContainer>
       <Header>
         <HeaderTextContainer>
-          <HeaderTitle>{dashboard.title}</HeaderTitle>
-          <LinkIcon onClick={() => window.open(dashboard.link, '_blank')} />
+          <HeaderTitle>{selectedDashboard.title}</HeaderTitle>
+          <LinkIcon onClick={() => window.open(selectedDashboard.contractLink, '_blank')} />
         </HeaderTextContainer>
-        <HeaderText dangerouslySetInnerHTML={{ __html: dashboard.description }} />
+        <HeaderText dangerouslySetInnerHTML={{ __html: selectedDashboard.description }} />
       </Header>
-      <DashboardChart dashboardType={selectedDashboard} strategyNames={dashboard.chartStrategyNames} />
-      <DashboardMetrics dashboardType={selectedDashboard} />
-      <DashboardTransactionHistory dashboardType={selectedDashboard} />
+      <DashboardChart dashboardData={selectedDashboard} />
+      <DashboardMetrics dashboardData={selectedDashboard} />
+      <DashboardTransactionHistory dashboardData={selectedDashboard} />
     </DashboardContentContainer>
   );
 };

--- a/apps/dapp/src/components/Pages/Core/DappPages/Dashboard/Metrics/index.tsx
+++ b/apps/dapp/src/components/Pages/Core/DappPages/Dashboard/Metrics/index.tsx
@@ -4,15 +4,15 @@ import { useMediaQuery } from 'react-responsive';
 import styled from 'styled-components';
 import * as breakpoints from 'styles/breakpoints';
 import { queryPhone } from 'styles/breakpoints';
-import { DashboardType } from '../DashboardContent';
+import { DashboardData } from '../DashboardConfig';
 import useDashboardV2Metrics, { ArrangedDashboardMetrics } from '../hooks/use-dashboardv2-metrics';
 
 type DashboardMetricsProps = {
-  dashboardType: DashboardType;
+  dashboardData: DashboardData;
 };
 
-const DashboardMetrics = ({ dashboardType }: DashboardMetricsProps) => {
-  const { dashboardMetrics } = useDashboardV2Metrics(dashboardType);
+const DashboardMetrics = ({ dashboardData }: DashboardMetricsProps) => {
+  const { dashboardMetrics } = useDashboardV2Metrics(dashboardData);
 
   const isDesktop = useMediaQuery({
     query: queryPhone,

--- a/apps/dapp/src/components/Pages/Core/DappPages/Dashboard/Table/TxnDataTable.tsx
+++ b/apps/dapp/src/components/Pages/Core/DappPages/Dashboard/Table/TxnDataTable.tsx
@@ -3,7 +3,6 @@ import { LoadingText } from 'components/Pages/Core/components/LoaderVault/common
 import env from 'constants/env';
 import styled from 'styled-components';
 import { loading } from 'utils/loading-value';
-import { StrategyKey } from '../hooks/use-dashboardv2-metrics';
 import { ArrowButtonUpDown } from 'components/Pages/Ascend/components/Trade/styles';
 import { TxHistoryTableHeader } from './TxnHistoryTable';
 import { useMediaQuery } from 'react-responsive';
@@ -12,6 +11,7 @@ import { queryMinTablet, queryPhone } from 'styles/breakpoints';
 import dropdownIcon from 'assets/icons/dropdown.svg?react';
 import { RowFilterDropdown, updateRowDropdownCheckbox } from './RowFilterDropdown';
 import { RowFilter } from '../hooks/use-dashboardv2-txHistory';
+import { StrategyKey } from '../DashboardConfig';
 
 export enum TxType {
   Borrow = 'Borrow',

--- a/apps/dapp/src/components/Pages/Core/DappPages/Dashboard/Table/TxnHistoryTable.tsx
+++ b/apps/dapp/src/components/Pages/Core/DappPages/Dashboard/Table/TxnHistoryTable.tsx
@@ -2,26 +2,20 @@ import { useState, useEffect, useMemo } from 'react';
 import type * as CSS from 'csstype';
 import styled from 'styled-components';
 import { TxHistoryFilterType } from '.';
-import { DashboardType } from '../DashboardContent';
 import { format } from 'date-fns';
 import { TableRow, TxType, TxnDataTable } from './TxnDataTable';
 import { PaginationControl } from './PaginationControl';
-import {
-  RowFilter,
-  dashboardTypeToStrategyKey,
-  useTxHistory,
-  useTxHistoryAvailableRows,
-} from '../hooks/use-dashboardv2-txHistory';
-import { StrategyKey } from '../hooks/use-dashboardv2-metrics';
+import { RowFilter, useTxHistory, useTxHistoryAvailableRows } from '../hooks/use-dashboardv2-txHistory';
 import { DropdownCheckOption, DropdownCheckOptions } from './RowFilterDropdown';
 import { useMediaQuery } from 'react-responsive';
 import { queryMinTablet } from 'styles/breakpoints';
 import env from 'constants/env';
 import linkSvg from 'assets/icons/link.svg?react';
 import { formatNumberWithCommas } from 'utils/formatter';
+import { DashboardData, Dashboards, isTRVDashboard } from '../DashboardConfig';
 
 type Props = {
-  dashboardType: DashboardType;
+  dashboardData: DashboardData;
   txFilter: TxHistoryFilterType;
 };
 
@@ -48,7 +42,7 @@ export type TxHistoryTableHeader = {
 };
 
 const TxnHistoryTable = (props: Props) => {
-  const { dashboardType, txFilter } = props;
+  const { dashboardData, txFilter } = props;
   const [currentPage, setCurrentPage] = useState(1);
   const [rowsPerPage, setRowsPerPage] = useState(10);
   const [blockNumber, setBlockNumber] = useState(0);
@@ -56,14 +50,7 @@ const TxnHistoryTable = (props: Props) => {
   const isBiggerThanTablet = useMediaQuery({ query: queryMinTablet });
 
   const allStrategyDropdowns = useMemo(
-    () => [
-      { label: StrategyKey.RAMOS, checked: false },
-      { label: StrategyKey.TLC, checked: false },
-      { label: StrategyKey.TEMPLEBASE, checked: false },
-      { label: StrategyKey.DSRBASE, checked: false },
-      { label: StrategyKey.TEMPLO_MAYOR_GNOSIS, checked: false },
-      { label: StrategyKey.FOHMO_GNOSIS, checked: false },
-    ],
+    () => Dashboards.map((dashboard) => ({ label: dashboard.key, checked: false })),
     []
   );
 
@@ -174,7 +161,7 @@ const TxnHistoryTable = (props: Props) => {
   };
 
   useEffect(() => {
-    const selectedStrategy = dashboardTypeToStrategyKey(dashboardType);
+    const selectedStrategy = dashboardData.key;
     setTableHeaders((prevState) => {
       // When user changes dashboard url:
       //  1. reset page
@@ -191,10 +178,9 @@ const TxnHistoryTable = (props: Props) => {
           return {
             ...prevStateHeader,
             orderDesc: undefined,
-            dropdownOptions:
-              selectedStrategy === StrategyKey.ALL
-                ? allStrategyDropdowns
-                : [{ label: selectedStrategy, checked: true }],
+            dropdownOptions: isTRVDashboard(selectedStrategy)
+              ? allStrategyDropdowns
+              : [{ label: selectedStrategy, checked: true }],
           };
         }
         //  3.2 reset all other dropdown values
@@ -211,14 +197,14 @@ const TxnHistoryTable = (props: Props) => {
       });
       return newState;
     });
-  }, [dashboardType, allStrategyDropdowns]);
+  }, [dashboardData.key, allStrategyDropdowns]);
 
   useEffect(() => {
     setCurrentPage(1);
   }, [rowsPerPage]);
 
   const availableRows = useTxHistoryAvailableRows({
-    dashboardType,
+    dashboardData,
     txFilter,
     rowFilter,
   });
@@ -228,7 +214,7 @@ const TxnHistoryTable = (props: Props) => {
   if (blockNumber === 0 && availableRows.data) setBlockNumber(availableRows.data.blockNumber);
 
   const txHistory = useTxHistory({
-    dashboardType,
+    dashboardData,
     txFilter,
     rowFilter,
     offset: (currentPage - 1) * rowsPerPage,
@@ -242,7 +228,11 @@ const TxnHistoryTable = (props: Props) => {
 
   // Fetch strategies tx data
   const dataToTable: TableRow[] | undefined = txHistory.data?.map((tx) => {
-    const amountResponsive = isBiggerThanTablet ? tx.amount : tx.name === TxType.Borrow ? Number(tx.amount) * -1 : tx.amount;
+    const amountResponsive = isBiggerThanTablet
+      ? tx.amount
+      : tx.name === TxType.Borrow
+      ? Number(tx.amount) * -1
+      : tx.amount;
     const amountFmt = formatNumberWithCommas(amountResponsive);
     const datetime = format(new Date(Number(tx.timestamp) * 1000), 'yyyy-MM-dd H:mm:ss O');
     const dateOnly = format(new Date(Number(tx.timestamp) * 1000), 'yyyy-MM-dd');

--- a/apps/dapp/src/components/Pages/Core/DappPages/Dashboard/Table/index.tsx
+++ b/apps/dapp/src/components/Pages/Core/DappPages/Dashboard/Table/index.tsx
@@ -1,12 +1,11 @@
 import { useState } from 'react';
-import { Button as BaseButton } from 'components/Button/Button';
 import styled from 'styled-components';
 import * as breakpoints from 'styles/breakpoints';
 import TxnHistoryTable from './TxnHistoryTable';
-import { DashboardType } from '../DashboardContent';
+import { DashboardData } from '../DashboardConfig';
 
 type DashboardTransactionHistoryProps = {
-  dashboardType: DashboardType;
+  dashboardData: DashboardData;
 };
 
 export enum TxHistoryFilterType {
@@ -15,7 +14,7 @@ export enum TxHistoryFilterType {
   all = 'all',
   }
 
-const DashboardTransactionHistory = ({ dashboardType }: DashboardTransactionHistoryProps) => {
+const DashboardTransactionHistory = ({ dashboardData }: DashboardTransactionHistoryProps) => {
   
   const [txFilter, setTxFilter] = useState<TxHistoryFilterType>(TxHistoryFilterType.all);
 
@@ -36,7 +35,7 @@ const DashboardTransactionHistory = ({ dashboardType }: DashboardTransactionHist
         </TransactionTimePeriod>
       </TransactionHistoryHeader>
       <TransactionHistoryContent>
-        <TxnHistoryTable dashboardType={dashboardType} txFilter={txFilter} />
+        <TxnHistoryTable dashboardData={dashboardData} txFilter={txFilter} />
       </TransactionHistoryContent>
     </TransactionHistoryContainer>
   );

--- a/apps/dapp/src/components/Pages/Core/DappPages/Dashboard/hooks/use-dashboardv2-daily-snapshots.ts
+++ b/apps/dapp/src/components/Pages/Core/DappPages/Dashboard/hooks/use-dashboardv2-daily-snapshots.ts
@@ -3,6 +3,7 @@ import env from 'constants/env';
 import { getQueryKey } from 'utils/react-query-helpers';
 import { SubGraphResponse } from 'hooks/core/types';
 import { fetchGenericSubgraph } from 'utils/subgraph';
+import { StrategyKey } from '../DashboardConfig';
 
 const V2SnapshotMetrics = [
   'totalMarketValueUSD',
@@ -44,7 +45,7 @@ const QUERIED_FIELDS = `
 export type V2StrategySnapshot = {
   timestamp: string;
   timeframe: string;
-  strategy: { name: string };
+  strategy: { name: StrategyKey };
   strategyTokens: { [key in (typeof STRATEGY_TOKEN_FIELDS)[number]]: string }[];
 } & { [key in V2SnapshotMetric]: string };
 

--- a/apps/dapp/src/components/Pages/Core/DappPages/Dashboard/hooks/use-dashboardv2-metrics.ts
+++ b/apps/dapp/src/components/Pages/Core/DappPages/Dashboard/hooks/use-dashboardv2-metrics.ts
@@ -1,19 +1,9 @@
 import { useQuery } from '@tanstack/react-query';
 import millify from 'millify';
 import { fetchGenericSubgraph } from 'utils/subgraph';
-import { DashboardType } from '../DashboardContent';
 import env from 'constants/env';
 import { getQueryKey } from 'utils/react-query-helpers';
-
-export enum StrategyKey {
-  RAMOS = 'RamosStrategy',
-  TLC = 'TlcStrategy',
-  TEMPLEBASE = 'TempleBaseStrategy',
-  DSRBASE = 'DsrBaseStrategy',
-  TEMPLO_MAYOR_GNOSIS = 'TemploMayorStrategy',
-  FOHMO_GNOSIS = 'FohmoStrategy',
-  ALL = 'All',
-}
+import { DashboardData, StrategyKey, TrvKey, isTRVDashboard } from '../DashboardConfig';
 
 export enum TokenSymbols {
   DAI = 'DAI',
@@ -54,108 +44,21 @@ export interface StrategyMetrics {
 
 const CACHE_TTL = 1000 * 60;
 
-export default function useDashboardV2Metrics(dashboardType: DashboardType) {
-  // TODO: In the future we can refactor this.
-  // Ideally should not enumerate every strategy but instead do it dynamically
-  // by e.g. iterating over the StrategyKey enum
-  // type MetricsMap = {
-  //   [strategy in StrategyKey]: UseQueryResult<StrategyMetrics>;
-  // };
-
-  const ramosMetrics = useQuery({
-    queryKey: getQueryKey.metrics(StrategyKey.RAMOS),
-    queryFn: async () => {
-      const metrics = await fetchStrategyMetrics(StrategyKey.RAMOS);
-      return metrics;
-    },
-    refetchInterval: CACHE_TTL,
-    staleTime: CACHE_TTL,
-  });
-
-  const tlcMetrics = useQuery({
-    queryKey: getQueryKey.metrics(StrategyKey.TLC),
-    queryFn: async () => {
-      const metrics = await fetchStrategyMetrics(StrategyKey.TLC);
-      return metrics;
-    },
-    refetchInterval: CACHE_TTL,
-    staleTime: CACHE_TTL,
-  });
-
-  const templeBaseMetrics = useQuery({
-    queryKey: getQueryKey.metrics(StrategyKey.TEMPLEBASE),
-    queryFn: async () => {
-      const metrics = await fetchStrategyMetrics(StrategyKey.TEMPLEBASE);
-      return metrics;
-    },
-    refetchInterval: CACHE_TTL,
-    staleTime: CACHE_TTL,
-  });
-
-  const dsrBaseMetrics = useQuery({
-    queryKey: getQueryKey.metrics(StrategyKey.DSRBASE),
-    queryFn: async () => {
-      const metrics = await fetchStrategyMetrics(StrategyKey.DSRBASE);
-      return metrics;
-    },
-    refetchInterval: CACHE_TTL,
-    staleTime: CACHE_TTL,
-  });
-
-  const treasuryReservesVaultMetrics = useQuery({
-    queryKey: getQueryKey.trvMetrics(DashboardType.TREASURY_RESERVES_VAULT),
-    queryFn: async () => {
-      const metrics = await fetchTreasuryReservesVaultMetrics();
-      return metrics;
-    },
-    refetchInterval: CACHE_TTL,
-    staleTime: CACHE_TTL,
-  });
-
-  const temploMayorGnosisMetrics = useQuery({
-    queryKey: getQueryKey.metrics(StrategyKey.TEMPLO_MAYOR_GNOSIS),
-    queryFn: async () => {
-      const metrics = await fetchStrategyMetrics(StrategyKey.TEMPLO_MAYOR_GNOSIS);
-      return metrics;
-    },
-    refetchInterval: CACHE_TTL,
-    staleTime: CACHE_TTL,
-  });
-
-  const fohmoGnosisMetrics = useQuery({
-    queryKey: getQueryKey.metrics(StrategyKey.FOHMO_GNOSIS),
-    queryFn: async () => {
-      const metrics = await fetchStrategyMetrics(StrategyKey.FOHMO_GNOSIS);
-      return metrics;
-    },
-    refetchInterval: CACHE_TTL,
-    staleTime: CACHE_TTL,
-  });
-
+export default function useDashboardV2Metrics(dashboardData: DashboardData) {
   const dashboardMetrics = useQuery({
-    queryKey: getQueryKey.metricsDashboard(dashboardType),
-    queryFn: () => {
-      switch (dashboardType) {
-        case DashboardType.TREASURY_RESERVES_VAULT:
-          return treasuryReservesVaultMetrics.data && getArrangedTreasuryReservesVaultMetrics(treasuryReservesVaultMetrics.data);
-        case DashboardType.TLC:
-          return tlcMetrics.data && getArrangedStrategyMetrics(tlcMetrics.data);
-        case DashboardType.RAMOS:
-          return ramosMetrics.data && getArrangedStrategyMetrics(ramosMetrics.data);
-        case DashboardType.TEMPLE_BASE:
-          return templeBaseMetrics.data && getArrangedStrategyMetrics(templeBaseMetrics.data);
-        case DashboardType.DSR_BASE:
-          return dsrBaseMetrics.data && getArrangedStrategyMetrics(dsrBaseMetrics.data);
-        case DashboardType.TEMPLO_MAYOR_GNOSIS:
-          return temploMayorGnosisMetrics.data && getArrangedStrategyMetrics(temploMayorGnosisMetrics.data);
-        case DashboardType.FOHMO_GNOSIS:
-          return fohmoGnosisMetrics.data && getArrangedStrategyMetrics(fohmoGnosisMetrics.data);
+    queryKey: getQueryKey.metricsDashboard(dashboardData.key),
+    queryFn: async () => {
+      if (isTRVDashboard(dashboardData.key)) {
+        return getArrangedTreasuryReservesVaultMetrics(await fetchTreasuryReservesVaultMetrics());
       }
-    },
-    enabled: !!treasuryReservesVaultMetrics.data && !!tlcMetrics.data && !!ramosMetrics.data && !!templeBaseMetrics.data && !!dsrBaseMetrics.data && !!temploMayorGnosisMetrics.data && !!fohmoGnosisMetrics.data
-  })
 
-  const fetchStrategyMetrics = async (strategy: StrategyKey): Promise<StrategyMetrics> => {
+      return getArrangedStrategyMetrics(await fetchStrategyMetrics(dashboardData.key));
+    },
+    refetchInterval: CACHE_TTL,
+    staleTime: CACHE_TTL,
+  });
+
+  const fetchStrategyMetrics = async (strategy: StrategyKey | TrvKey): Promise<StrategyMetrics> => {
     let metrics = {
       valueOfHoldings: 0,
       benchmarkedEquity: 0,

--- a/apps/dapp/src/components/Pages/Core/DappPages/Dashboard/hooks/use-dashboardv2-txHistory.ts
+++ b/apps/dapp/src/components/Pages/Core/DappPages/Dashboard/hooks/use-dashboardv2-txHistory.ts
@@ -2,12 +2,11 @@ import { fetchGenericSubgraph } from 'utils/subgraph';
 import env from 'constants/env';
 import { SubGraphResponse } from 'hooks/core/types';
 import { TxHistoryFilterType } from '../Table';
-import { DashboardType } from '../DashboardContent';
-import { StrategyKey } from './use-dashboardv2-metrics';
 import { TableHeaders, TxHistoryTableHeader } from '../Table/TxnHistoryTable';
 import { TxType } from '../Table/TxnDataTable';
 import { getQueryKey } from 'utils/react-query-helpers';
 import { useQuery } from '@tanstack/react-query';
+import { DashboardData, StrategyKey, isTRVDashboard } from '../DashboardConfig';
 
 type Transactions = {
   hash: string;
@@ -58,7 +57,7 @@ export type RowFilter = {
 };
 
 export type TxHistoryProps = {
-  dashboardType: DashboardType;
+  dashboardData: DashboardData;
   txFilter: TxHistoryFilterType;
   rowFilter: RowFilter;
   offset: number;
@@ -68,10 +67,10 @@ export type TxHistoryProps = {
 };
 
 export type TxHistoryAvailableRowsProps = {
-  dashboardType: DashboardType;
+  dashboardData: DashboardData;
   txFilter: TxHistoryFilterType;
   rowFilter: RowFilter;
-}
+};
 
 const txHistoryFilterTypeToSeconds = (filter: TxHistoryFilterType) => {
   const dateNowSecs = Math.round(Date.now() / 1000);
@@ -83,25 +82,6 @@ const txHistoryFilterTypeToSeconds = (filter: TxHistoryFilterType) => {
       return oneDaySecs * 30;
     case TxHistoryFilterType.lastweek:
       return oneDaySecs * 7;
-  }
-};
-
-export const dashboardTypeToStrategyKey = (dType: DashboardType): StrategyKey => {
-  switch (dType) {
-    case DashboardType.TLC:
-      return StrategyKey.TLC;
-    case DashboardType.RAMOS:
-      return StrategyKey.RAMOS;
-    case DashboardType.DSR_BASE:
-      return StrategyKey.DSRBASE;
-    case DashboardType.TEMPLE_BASE:
-      return StrategyKey.TEMPLEBASE;
-    case DashboardType.TEMPLO_MAYOR_GNOSIS:
-      return StrategyKey.TEMPLO_MAYOR_GNOSIS;
-    case DashboardType.FOHMO_GNOSIS:
-      return StrategyKey.FOHMO_GNOSIS;
-    default:
-      return StrategyKey.ALL;
   }
 };
 
@@ -130,20 +110,20 @@ const useTxHistory = (props: TxHistoryProps) =>
   });
 
 const fetchTransactions = async (props: TxHistoryProps): Promise<Transactions> => {
-  const { dashboardType, blockNumber, offset, limit, txFilter, rowFilter, tableHeaders } = props;
+  const { dashboardData, blockNumber, offset, limit, txFilter, rowFilter, tableHeaders } = props;
 
-  const strategyKey = dashboardTypeToStrategyKey(dashboardType);
-  const strategyQuery = strategyKey === StrategyKey.ALL ? `` : `strategy_: {name: "${strategyKey}"}`;
-  const blockNumberQueryParam = blockNumber > 0 ? (`block: { number: ${blockNumber} }`) : ``;
+  const strategyKey = dashboardData.key;
+  const strategyQuery = isTRVDashboard(strategyKey) ? `` : `strategy_: {name: "${strategyKey}"}`;
+  const blockNumberQueryParam = blockNumber > 0 ? `block: { number: ${blockNumber} }` : ``;
 
   const paginationQuery = `skip: ${offset} first: ${limit}`;
 
   const dateNowSecs = Math.round(Date.now() / 1000);
-  const typeRowFilterQuery = `${rowFilter.type ? ('name_contains_nocase: "' + rowFilter.type + '"') : ''}`;
+  const typeRowFilterQuery = `${rowFilter.type ? 'name_contains_nocase: "' + rowFilter.type + '"' : ''}`;
   const strategyRowFilterQuery = `${
-    rowFilter.strategy ? ('strategy_: {name_contains_nocase: "' + rowFilter.strategy + '"}') : ''
+    rowFilter.strategy ? 'strategy_: {name_contains_nocase: "' + rowFilter.strategy + '"}' : ''
   }`;
-  const tokenRowFilterQuery = `${rowFilter.token ? ('token_: {symbol_contains_nocase: "' + rowFilter.token + '"}') : ''}`;
+  const tokenRowFilterQuery = `${rowFilter.token ? 'token_: {symbol_contains_nocase: "' + rowFilter.token + '"}' : ''}`;
   const whereQuery = `
     ${blockNumberQueryParam} 
     where: { 
@@ -188,24 +168,24 @@ const fetchTransactions = async (props: TxHistoryProps): Promise<Transactions> =
 const useTxHistoryAvailableRows = (props: TxHistoryAvailableRowsProps) =>
   useQuery({
     queryKey: getQueryKey.txHistoryAvailableRows(props),
-    queryFn: () => fetchTxHistoryAvailableRows(props)
+    queryFn: () => fetchTxHistoryAvailableRows(props),
   });
 
 const fetchTxHistoryAvailableRows = async (props: TxHistoryAvailableRowsProps): Promise<AvailableRows> => {
-  const {dashboardType, rowFilter, txFilter} = props;
-  const strategyKey = dashboardTypeToStrategyKey(dashboardType);
-  const strategyQuery = strategyKey === StrategyKey.ALL ? `` : `strategy_: {name: "${strategyKey}"}`;
+  const { dashboardData, rowFilter, txFilter } = props;
+  const strategyKey = dashboardData.key;
+  const strategyQuery = isTRVDashboard(strategyKey) ? `` : `strategy_: {name: "${strategyKey}"}`;
   const dateNowSecs = Math.round(Date.now() / 1000);
-  const typeRowFilterQuery = `${rowFilter.type ? ('name_contains_nocase: "' + rowFilter.type + '"') : ''}`;
+  const typeRowFilterQuery = `${rowFilter.type ? 'name_contains_nocase: "' + rowFilter.type + '"' : ''}`;
   const strategyRowFilterQuery = `${
-    rowFilter.strategy ? ('strategy_: {name_contains_nocase: "' + rowFilter.strategy + '"}') : ''
+    rowFilter.strategy ? 'strategy_: {name_contains_nocase: "' + rowFilter.strategy + '"}' : ''
   }`;
-  const tokenRowFilterQuery = `${rowFilter.token ? ('token_: {symbol_contains_nocase: "' + rowFilter.token + '"}') : ''}`;
+  const tokenRowFilterQuery = `${rowFilter.token ? 'token_: {symbol_contains_nocase: "' + rowFilter.token + '"}' : ''}`;
   // get the max allowed 1000 records for a more accurate totalPages calculation
   const whereQuery = `( first: 1000 
     where: { 
       ${strategyQuery} 
-      timestamp_gt: ${ dateNowSecs - txHistoryFilterTypeToSeconds(txFilter) } 
+      timestamp_gt: ${dateNowSecs - txHistoryFilterTypeToSeconds(txFilter)} 
       ${typeRowFilterQuery} 
       ${strategyRowFilterQuery} 
       ${tokenRowFilterQuery}
@@ -238,8 +218,7 @@ const fetchTxHistoryAvailableRows = async (props: TxHistoryAvailableRowsProps): 
   if (rowFilter.type) hasRowFilters = rowFilter.type.length > 0;
   if (res) {
     let totalRowCount = 0;
-    // if (props.txFilter === TxHistoryFilterType.all && strategyKey === StrategyKey.ALL && (rowFilters && rowFilters?.length === 0)) {
-    if (props.txFilter === TxHistoryFilterType.all && strategyKey === StrategyKey.ALL && !hasRowFilters) {
+    if (props.txFilter === TxHistoryFilterType.all && isTRVDashboard(strategyKey) && !hasRowFilters) {
       // if user chooses all transactions, sum the txCountTotal of every strategy, we don't use this
       // calc for the last30days or lastweek filters because it could show an incorrect number of totalPages
       totalRowCount = res.metrics[0].strategyTransactionCount;

--- a/apps/dapp/src/components/Pages/Core/DappPages/Dashboard/index.tsx
+++ b/apps/dapp/src/components/Pages/Core/DappPages/Dashboard/index.tsx
@@ -1,7 +1,8 @@
 import { Route, Routes, NavLink as BaseNavLink, Navigate, useSearchParams } from 'react-router-dom';
 import * as breakpoints from 'styles/breakpoints';
 import styled from 'styled-components';
-import DashboardContent, { DashboardType } from './DashboardContent';
+import DashboardContent from './DashboardContent';
+import { Dashboards } from './DashboardConfig';
 
 export const DashboardPage = () => {
   const [searchParams] = useSearchParams();
@@ -10,41 +11,22 @@ export const DashboardPage = () => {
   return (
     <DashboardContainer>
       <DashboardHeaderNav>
-        <NavCell>
-          <NavLink to={`treasuryreservesvault?${params}`}>TRV</NavLink>
-        </NavCell>
-        <NavCell>
-          <NavLink to={`ramos?${params}`}>RAMOS</NavLink>
-        </NavCell>
-        <NavCell>
-          <NavLink to={`tlc?${params}`}>TLC</NavLink>
-        </NavCell>
-        <NavCell>
-          <NavLink to={`templebase?${params}`}>TEMPLE BASE</NavLink>
-        </NavCell>
-        <NavCell>
-          <NavLink to={`dsrbase?${params}`}>DSR BASE</NavLink>
-        </NavCell>
-        <NavCell>
-          <NavLink to={`templomayor?${params}`}>TEMPLO MAYOR</NavLink>
-        </NavCell>
-        <NavCell>
-          <NavLink to={`fohmo?${params}`}>FOHMO</NavLink>
-        </NavCell>
+        {Dashboards.map((dashboard) => (
+          <NavCell key={dashboard.key}>
+            <NavLink to={`${dashboard.path}?${params}`}>{dashboard.title}</NavLink>
+          </NavCell>
+        ))}
       </DashboardHeaderNav>
       <DashboardContentContainer>
         <Routes>
           <Route path="*" element={<Navigate replace to="treasuryreservesvault" />} />
-          <Route
-            path="treasuryreservesvault"
-            element={<DashboardContent selectedDashboard={DashboardType.TREASURY_RESERVES_VAULT} />}
-          />
-          <Route path="ramos" element={<DashboardContent selectedDashboard={DashboardType.RAMOS} />} />
-          <Route path="tlc" element={<DashboardContent selectedDashboard={DashboardType.TLC} />} />
-          <Route path="templebase" element={<DashboardContent selectedDashboard={DashboardType.TEMPLE_BASE} />} />
-          <Route path="dsrbase" element={<DashboardContent selectedDashboard={DashboardType.DSR_BASE} />} />
-          <Route path="templomayor" element={<DashboardContent selectedDashboard={DashboardType.TEMPLO_MAYOR_GNOSIS} />} />
-          <Route path="fohmo" element={<DashboardContent selectedDashboard={DashboardType.FOHMO_GNOSIS} />} />
+          {Dashboards.map((dashboard) => (
+            <Route
+              key={dashboard.key}
+              path={dashboard.path}
+              element={<DashboardContent selectedDashboard={dashboard} />}
+            />
+          ))}
         </Routes>
       </DashboardContentContainer>
     </DashboardContainer>
@@ -70,7 +52,7 @@ const NavLink = styled(BaseNavLink)<NavLinkProps>`
 
   &.active {
     text-decoration: underline;
-    color: ${({theme})=> theme.palette.brandLight}
+    color: ${({ theme }) => theme.palette.brandLight};
   }
 
   ${breakpoints.phoneToSmallTablet(`

--- a/apps/dapp/src/utils/react-query-helpers.ts
+++ b/apps/dapp/src/utils/react-query-helpers.ts
@@ -1,15 +1,14 @@
-import { DashboardType } from 'components/Pages/Core/DappPages/Dashboard/DashboardContent';
-import { StrategyKey } from 'components/Pages/Core/DappPages/Dashboard/hooks/use-dashboardv2-metrics';
+import { StrategyKey, TrvKey } from 'components/Pages/Core/DappPages/Dashboard/DashboardConfig';
 import { TxHistoryAvailableRowsProps, TxHistoryProps } from 'components/Pages/Core/DappPages/Dashboard/hooks/use-dashboardv2-txHistory';
 
 // Centralize all the dApp react query keys in case we need to cancel or invalidate them
 // through the app, this makes it easier to track them, please add new ones as required
 export const getQueryKey = {
-  txHistory: (props: TxHistoryProps) => ['TxHistory', props.dashboardType, props.txFilter, props.rowFilter, props.offset, props.limit, props.blockNumber, props.tableHeaders],
-  txHistoryAvailableRows: (props: TxHistoryAvailableRowsProps) => ['TxHistoryAvailableRows', props.dashboardType, props.txFilter, props.rowFilter],
+  txHistory: (props: TxHistoryProps) => ['TxHistory', props.dashboardData, props.txFilter, props.rowFilter, props.offset, props.limit, props.blockNumber, props.tableHeaders],
+  txHistoryAvailableRows: (props: TxHistoryAvailableRowsProps) => ['TxHistoryAvailableRows', props.dashboardData, props.txFilter, props.rowFilter],
   metrics: (s?: StrategyKey) => (s ? ['getMetrics', s] : ['getMetrics']),
-  metricsDashboard: (d: DashboardType) => (['metricsDashboard', d]),
-  trvMetrics: (d?: DashboardType) => (d ? ['getTreasureReserveMetrics', d] : ['getTreasureReserveMetrics']),
+  metricsDashboard: (s: StrategyKey | TrvKey) => (['metricsDashboard', s]),
+  trvMetrics: (s?: StrategyKey) => (s ? ['getTreasureReserveMetrics', s] : ['getTreasureReserveMetrics']),
   allStrategiesDailySnapshots: () => ['strategyDailySnapshots'],
   allStrategiesHourlySnapshots: () => ['strategyHourlySnapshots'],
 };


### PR DESCRIPTION
# Description

This is a refactor motivated by previous [pain](https://github.com/TempleDAO/temple/pull/954) we experienced when adding a new strategy to the Dashboard.

The approach is basically to centralize all the dashboard data, and pass the selected dashboard data around from the root level. Anywhere we multiple copies of the same thing based on each dashboard (e.g. navlinks, "react query" queries for metrics, etc) we do that dynamically.

In the end, we should only have to edit a single file when updating strategies on the Dashboard. (DashboardConfig.tsx)
