### PR TITLE
Remove ALL and TRV strategy keys

### DIFF
--- a/apps/dapp/src/components/Pages/Core/DappPages/Dashboard/Chart/V2StrategyMetricsChart.tsx
+++ b/apps/dapp/src/components/Pages/Core/DappPages/Dashboard/Chart/V2StrategyMetricsChart.tsx
@@ -9,7 +9,7 @@ import useV2StrategySnapshotData, {
   V2SnapshotMetric,
   V2StrategySnapshot,
 } from '../hooks/use-dashboardv2-daily-snapshots';
-import { ALL_STRATEGIES, DashboardData, StrategyKey, isTRVStrategy } from '../DashboardConfig';
+import { ALL_STRATEGIES, DashboardData, isTRVDashboard } from '../DashboardConfig';
 
 type XAxisTickFormatter = (timestamp: number) => string;
 
@@ -74,7 +74,7 @@ const V2StrategyMetricsChart: React.FC<{
   // uncamel-case the metric names
   const formatMetricName = (name: string) =>
     // format only the selected metric name (the selected metric or all lines in a TRV chart)
-    name === selectedMetric || isTRVStrategy(dashboardData.key)
+    name === selectedMetric || isTRVDashboard(dashboardData.key)
       ? name
           // // insert a space before all caps
           .replace(/([A-Z][a-z])/g, ' $1')
@@ -137,7 +137,7 @@ const V2StrategyMetricsChart: React.FC<{
 
   // TRV dashboard shows all defined strategies as single lines
   // all other dashboards show just the selected strategy key
-  const chartStrategyNames = isTRVStrategy(dashboardData.key) ? ALL_STRATEGIES : [dashboardData.key];
+  const chartStrategyNames = isTRVDashboard(dashboardData.key) ? ALL_STRATEGIES : [dashboardData.key];
 
   const filteredDaily =
     dailyMetrics
@@ -185,14 +185,14 @@ const V2StrategyMetricsChart: React.FC<{
 
   // TRV renders selected metric of all strategies as multiline chart
   // other dashboards show the selected metric only (single line)
-  const lines = isTRVStrategy(dashboardData.key)
+  const lines = isTRVDashboard(dashboardData.key)
     ? metrics.map((metric, ix) => ({ series: metric, color: colors[ix % colors.length] }))
     : [{ series: selectedMetric, color: colors[0] }];
 
   // for non trv dashboard, pluck all other metrics
   // (individual assets that make up the metric)
   // to render as stacked area chart
-  const stackedItems = !isTRVStrategy(dashboardData.key)
+  const stackedItems = !isTRVDashboard(dashboardData.key)
     ? // add +1 to skip the first color which is always the selectedMetric
       metrics
         .filter((m) => m !== selectedMetric)

--- a/apps/dapp/src/components/Pages/Core/DappPages/Dashboard/DashboardConfig.tsx
+++ b/apps/dapp/src/components/Pages/Core/DappPages/Dashboard/DashboardConfig.tsx
@@ -1,5 +1,9 @@
 import env from 'constants/env';
 
+/*
+ Note that the StrategyKey matches what's in the contracts
+ https://github.com/TempleDAO/temple/blob/stage/protocol/contracts/interfaces/v2/strategies/ITempleStrategy.sol#L57
+*/
 export enum StrategyKey {
   RAMOS = 'RamosStrategy',
   // TLC = 'TlcStrategy',
@@ -7,13 +11,18 @@ export enum StrategyKey {
   DSRBASE = 'DsrBaseStrategy',
   TEMPLO_MAYOR_GNOSIS = 'TemploMayorStrategy',
   FOHMO_GNOSIS = 'FohmoStrategy',
-  ALL = 'All',
-  // TODO: This probably could be consolidated with ALL
-  TREASURY_RESERVES_VAULT = 'TreasuryReservesVault',
 }
 
+// Except this special case for the Treasury Reserves Vault dashboard
+export const TRV_KEY = 'TreasuryReservesVault';
+export type TrvKey = typeof TRV_KEY;
+
+export const ALL_STRATEGIES = Object.values(StrategyKey);
+
+export const isTRVStrategy = (strategy: StrategyKey | TrvKey) => strategy === TRV_KEY;
+
 export type DashboardData = {
-  key: StrategyKey;
+  key: StrategyKey | TrvKey;
   name: string;
   title: string;
   path: string;
@@ -23,7 +32,7 @@ export type DashboardData = {
 
 export const Dashboards: DashboardData[] = [
   {
-    key: StrategyKey.TREASURY_RESERVES_VAULT,
+    key: TRV_KEY,
     name: 'Treasury Reserves Vault',
     title: 'TRV',
     path: 'treasuryreservesvault',

--- a/apps/dapp/src/components/Pages/Core/DappPages/Dashboard/DashboardConfig.tsx
+++ b/apps/dapp/src/components/Pages/Core/DappPages/Dashboard/DashboardConfig.tsx
@@ -19,7 +19,7 @@ export type TrvKey = typeof TRV_KEY;
 
 export const ALL_STRATEGIES = Object.values(StrategyKey);
 
-export const isTRVStrategy = (strategy: StrategyKey | TrvKey) => strategy === TRV_KEY;
+export const isTRVDashboard = (strategy: StrategyKey | TrvKey) => strategy === TRV_KEY;
 
 export type DashboardData = {
   key: StrategyKey | TrvKey;

--- a/apps/dapp/src/components/Pages/Core/DappPages/Dashboard/Table/TxnHistoryTable.tsx
+++ b/apps/dapp/src/components/Pages/Core/DappPages/Dashboard/Table/TxnHistoryTable.tsx
@@ -12,7 +12,7 @@ import { queryMinTablet } from 'styles/breakpoints';
 import env from 'constants/env';
 import linkSvg from 'assets/icons/link.svg?react';
 import { formatNumberWithCommas } from 'utils/formatter';
-import { DashboardData, Dashboards, isTRVStrategy } from '../DashboardConfig';
+import { DashboardData, Dashboards, isTRVDashboard } from '../DashboardConfig';
 
 type Props = {
   dashboardData: DashboardData;
@@ -178,7 +178,7 @@ const TxnHistoryTable = (props: Props) => {
           return {
             ...prevStateHeader,
             orderDesc: undefined,
-            dropdownOptions: isTRVStrategy(selectedStrategy)
+            dropdownOptions: isTRVDashboard(selectedStrategy)
               ? allStrategyDropdowns
               : [{ label: selectedStrategy, checked: true }],
           };

--- a/apps/dapp/src/components/Pages/Core/DappPages/Dashboard/Table/TxnHistoryTable.tsx
+++ b/apps/dapp/src/components/Pages/Core/DappPages/Dashboard/Table/TxnHistoryTable.tsx
@@ -12,7 +12,7 @@ import { queryMinTablet } from 'styles/breakpoints';
 import env from 'constants/env';
 import linkSvg from 'assets/icons/link.svg?react';
 import { formatNumberWithCommas } from 'utils/formatter';
-import { DashboardData, StrategyKey, Dashboards } from '../DashboardConfig';
+import { DashboardData, Dashboards, isTRVStrategy } from '../DashboardConfig';
 
 type Props = {
   dashboardData: DashboardData;
@@ -178,10 +178,9 @@ const TxnHistoryTable = (props: Props) => {
           return {
             ...prevStateHeader,
             orderDesc: undefined,
-            dropdownOptions:
-              selectedStrategy === StrategyKey.ALL
-                ? allStrategyDropdowns
-                : [{ label: selectedStrategy, checked: true }],
+            dropdownOptions: isTRVStrategy(selectedStrategy)
+              ? allStrategyDropdowns
+              : [{ label: selectedStrategy, checked: true }],
           };
         }
         //  3.2 reset all other dropdown values

--- a/apps/dapp/src/components/Pages/Core/DappPages/Dashboard/hooks/use-dashboardv2-metrics.ts
+++ b/apps/dapp/src/components/Pages/Core/DappPages/Dashboard/hooks/use-dashboardv2-metrics.ts
@@ -3,7 +3,7 @@ import millify from 'millify';
 import { fetchGenericSubgraph } from 'utils/subgraph';
 import env from 'constants/env';
 import { getQueryKey } from 'utils/react-query-helpers';
-import { DashboardData, StrategyKey } from '../DashboardConfig';
+import { DashboardData, StrategyKey, TrvKey, isTRVStrategy } from '../DashboardConfig';
 
 export enum TokenSymbols {
   DAI = 'DAI',
@@ -48,7 +48,7 @@ export default function useDashboardV2Metrics(dashboardData: DashboardData) {
   const dashboardMetrics = useQuery({
     queryKey: getQueryKey.metricsDashboard(dashboardData.key),
     queryFn: async () => {
-      if (dashboardData.key === StrategyKey.TREASURY_RESERVES_VAULT) {
+      if (isTRVStrategy(dashboardData.key)) {
         return getArrangedTreasuryReservesVaultMetrics(await fetchTreasuryReservesVaultMetrics());
       }
 
@@ -58,7 +58,7 @@ export default function useDashboardV2Metrics(dashboardData: DashboardData) {
     staleTime: CACHE_TTL,
   });
 
-  const fetchStrategyMetrics = async (strategy: StrategyKey): Promise<StrategyMetrics> => {
+  const fetchStrategyMetrics = async (strategy: StrategyKey | TrvKey): Promise<StrategyMetrics> => {
     let metrics = {
       valueOfHoldings: 0,
       benchmarkedEquity: 0,

--- a/apps/dapp/src/components/Pages/Core/DappPages/Dashboard/hooks/use-dashboardv2-metrics.ts
+++ b/apps/dapp/src/components/Pages/Core/DappPages/Dashboard/hooks/use-dashboardv2-metrics.ts
@@ -3,7 +3,7 @@ import millify from 'millify';
 import { fetchGenericSubgraph } from 'utils/subgraph';
 import env from 'constants/env';
 import { getQueryKey } from 'utils/react-query-helpers';
-import { DashboardData, StrategyKey, TrvKey, isTRVStrategy } from '../DashboardConfig';
+import { DashboardData, StrategyKey, TrvKey, isTRVDashboard } from '../DashboardConfig';
 
 export enum TokenSymbols {
   DAI = 'DAI',
@@ -48,7 +48,7 @@ export default function useDashboardV2Metrics(dashboardData: DashboardData) {
   const dashboardMetrics = useQuery({
     queryKey: getQueryKey.metricsDashboard(dashboardData.key),
     queryFn: async () => {
-      if (isTRVStrategy(dashboardData.key)) {
+      if (isTRVDashboard(dashboardData.key)) {
         return getArrangedTreasuryReservesVaultMetrics(await fetchTreasuryReservesVaultMetrics());
       }
 

--- a/apps/dapp/src/components/Pages/Core/DappPages/Dashboard/hooks/use-dashboardv2-txHistory.ts
+++ b/apps/dapp/src/components/Pages/Core/DappPages/Dashboard/hooks/use-dashboardv2-txHistory.ts
@@ -6,7 +6,7 @@ import { TableHeaders, TxHistoryTableHeader } from '../Table/TxnHistoryTable';
 import { TxType } from '../Table/TxnDataTable';
 import { getQueryKey } from 'utils/react-query-helpers';
 import { useQuery } from '@tanstack/react-query';
-import { DashboardData, StrategyKey } from '../DashboardConfig';
+import { DashboardData, StrategyKey, isTRVStrategy } from '../DashboardConfig';
 
 type Transactions = {
   hash: string;
@@ -113,7 +113,7 @@ const fetchTransactions = async (props: TxHistoryProps): Promise<Transactions> =
   const { dashboardData, blockNumber, offset, limit, txFilter, rowFilter, tableHeaders } = props;
 
   const strategyKey = dashboardData.key;
-  const strategyQuery = strategyKey === StrategyKey.ALL ? `` : `strategy_: {name: "${strategyKey}"}`;
+  const strategyQuery = isTRVStrategy(strategyKey) ? `` : `strategy_: {name: "${strategyKey}"}`;
   const blockNumberQueryParam = blockNumber > 0 ? `block: { number: ${blockNumber} }` : ``;
 
   const paginationQuery = `skip: ${offset} first: ${limit}`;
@@ -174,7 +174,7 @@ const useTxHistoryAvailableRows = (props: TxHistoryAvailableRowsProps) =>
 const fetchTxHistoryAvailableRows = async (props: TxHistoryAvailableRowsProps): Promise<AvailableRows> => {
   const { dashboardData, rowFilter, txFilter } = props;
   const strategyKey = dashboardData.key;
-  const strategyQuery = strategyKey === StrategyKey.ALL ? `` : `strategy_: {name: "${strategyKey}"}`;
+  const strategyQuery = isTRVStrategy(strategyKey) ? `` : `strategy_: {name: "${strategyKey}"}`;
   const dateNowSecs = Math.round(Date.now() / 1000);
   const typeRowFilterQuery = `${rowFilter.type ? 'name_contains_nocase: "' + rowFilter.type + '"' : ''}`;
   const strategyRowFilterQuery = `${
@@ -218,8 +218,7 @@ const fetchTxHistoryAvailableRows = async (props: TxHistoryAvailableRowsProps): 
   if (rowFilter.type) hasRowFilters = rowFilter.type.length > 0;
   if (res) {
     let totalRowCount = 0;
-    // if (props.txFilter === TxHistoryFilterType.all && strategyKey === StrategyKey.ALL && (rowFilters && rowFilters?.length === 0)) {
-    if (props.txFilter === TxHistoryFilterType.all && strategyKey === StrategyKey.ALL && !hasRowFilters) {
+    if (props.txFilter === TxHistoryFilterType.all && isTRVStrategy(strategyKey) && !hasRowFilters) {
       // if user chooses all transactions, sum the txCountTotal of every strategy, we don't use this
       // calc for the last30days or lastweek filters because it could show an incorrect number of totalPages
       totalRowCount = res.metrics[0].strategyTransactionCount;

--- a/apps/dapp/src/components/Pages/Core/DappPages/Dashboard/hooks/use-dashboardv2-txHistory.ts
+++ b/apps/dapp/src/components/Pages/Core/DappPages/Dashboard/hooks/use-dashboardv2-txHistory.ts
@@ -6,7 +6,7 @@ import { TableHeaders, TxHistoryTableHeader } from '../Table/TxnHistoryTable';
 import { TxType } from '../Table/TxnDataTable';
 import { getQueryKey } from 'utils/react-query-helpers';
 import { useQuery } from '@tanstack/react-query';
-import { DashboardData, StrategyKey, isTRVStrategy } from '../DashboardConfig';
+import { DashboardData, StrategyKey, isTRVDashboard } from '../DashboardConfig';
 
 type Transactions = {
   hash: string;
@@ -113,7 +113,7 @@ const fetchTransactions = async (props: TxHistoryProps): Promise<Transactions> =
   const { dashboardData, blockNumber, offset, limit, txFilter, rowFilter, tableHeaders } = props;
 
   const strategyKey = dashboardData.key;
-  const strategyQuery = isTRVStrategy(strategyKey) ? `` : `strategy_: {name: "${strategyKey}"}`;
+  const strategyQuery = isTRVDashboard(strategyKey) ? `` : `strategy_: {name: "${strategyKey}"}`;
   const blockNumberQueryParam = blockNumber > 0 ? `block: { number: ${blockNumber} }` : ``;
 
   const paginationQuery = `skip: ${offset} first: ${limit}`;
@@ -174,7 +174,7 @@ const useTxHistoryAvailableRows = (props: TxHistoryAvailableRowsProps) =>
 const fetchTxHistoryAvailableRows = async (props: TxHistoryAvailableRowsProps): Promise<AvailableRows> => {
   const { dashboardData, rowFilter, txFilter } = props;
   const strategyKey = dashboardData.key;
-  const strategyQuery = isTRVStrategy(strategyKey) ? `` : `strategy_: {name: "${strategyKey}"}`;
+  const strategyQuery = isTRVDashboard(strategyKey) ? `` : `strategy_: {name: "${strategyKey}"}`;
   const dateNowSecs = Math.round(Date.now() / 1000);
   const typeRowFilterQuery = `${rowFilter.type ? 'name_contains_nocase: "' + rowFilter.type + '"' : ''}`;
   const strategyRowFilterQuery = `${
@@ -218,7 +218,7 @@ const fetchTxHistoryAvailableRows = async (props: TxHistoryAvailableRowsProps): 
   if (rowFilter.type) hasRowFilters = rowFilter.type.length > 0;
   if (res) {
     let totalRowCount = 0;
-    if (props.txFilter === TxHistoryFilterType.all && isTRVStrategy(strategyKey) && !hasRowFilters) {
+    if (props.txFilter === TxHistoryFilterType.all && isTRVDashboard(strategyKey) && !hasRowFilters) {
       // if user chooses all transactions, sum the txCountTotal of every strategy, we don't use this
       // calc for the last30days or lastweek filters because it could show an incorrect number of totalPages
       totalRowCount = res.metrics[0].strategyTransactionCount;

--- a/apps/dapp/src/utils/react-query-helpers.ts
+++ b/apps/dapp/src/utils/react-query-helpers.ts
@@ -1,4 +1,4 @@
-import { StrategyKey } from 'components/Pages/Core/DappPages/Dashboard/DashboardConfig';
+import { StrategyKey, TrvKey } from 'components/Pages/Core/DappPages/Dashboard/DashboardConfig';
 import { TxHistoryAvailableRowsProps, TxHistoryProps } from 'components/Pages/Core/DappPages/Dashboard/hooks/use-dashboardv2-txHistory';
 
 // Centralize all the dApp react query keys in case we need to cancel or invalidate them
@@ -7,7 +7,7 @@ export const getQueryKey = {
   txHistory: (props: TxHistoryProps) => ['TxHistory', props.dashboardData, props.txFilter, props.rowFilter, props.offset, props.limit, props.blockNumber, props.tableHeaders],
   txHistoryAvailableRows: (props: TxHistoryAvailableRowsProps) => ['TxHistoryAvailableRows', props.dashboardData, props.txFilter, props.rowFilter],
   metrics: (s?: StrategyKey) => (s ? ['getMetrics', s] : ['getMetrics']),
-  metricsDashboard: (s: StrategyKey) => (['metricsDashboard', s]),
+  metricsDashboard: (s: StrategyKey | TrvKey) => (['metricsDashboard', s]),
   trvMetrics: (s?: StrategyKey) => (s ? ['getTreasureReserveMetrics', s] : ['getTreasureReserveMetrics']),
   allStrategiesDailySnapshots: () => ['strategyDailySnapshots'],
   allStrategiesHourlySnapshots: () => ['strategyHourlySnapshots'],


### PR DESCRIPTION
# Description

Responding to the feedback from https://github.com/TempleDAO/temple/pull/980#discussion_r1513068442 , I took the following approach:

- Remove ALL and TREASURY_RESERVES_VAULT StrategyKeys
- Added a special TRV_KEY and type instead of an `undefined` (this to me is better than using undefined)
- Add isTRVStrategy helper method to consolidate logic and keep a separation of concerns.


# Checklist
- [ ] Code follows the style guide
- [ ] I have performed a self-review of my own code
- [ ] New and existing tests pass locally
- [ ] This PR is targeting the correct branch 