### PR TITLE
Add no-array-index-key eslint rule

### DIFF
--- a/apps/dapp/.eslintrc
+++ b/apps/dapp/.eslintrc
@@ -16,7 +16,8 @@
     "react/prop-types": "off",
     "no-console": "off",
     "react/jsx-uses-react": "off",
-    "react/react-in-jsx-scope": "off"
+    "react/react-in-jsx-scope": "off",
+    "react/no-array-index-key": "error"
   },
   "settings": {
     "react": {

--- a/apps/dapp/package.json
+++ b/apps/dapp/package.json
@@ -6,6 +6,7 @@
   },
   "scripts": {
     "typechain": "typechain --target=ethers-v5 --out-dir src/types/typechain --glob abi/**/*.json",
+    "lint": "eslint ./src",
     "prepare": "yarn typechain && yarn codegen:safe-api-v1",
     "dev": "vite",
     "compile": "tsc",

--- a/apps/dapp/src/components/Layouts/Ascend/PillMenu/index.tsx
+++ b/apps/dapp/src/components/Layouts/Ascend/PillMenu/index.tsx
@@ -16,8 +16,8 @@ export const PillMenu = ({ links }: Props) => {
   return (
     <MenuWrapper>
       <Menu>
-        {links.map(({ to, label, onClick }, i) => (
-          <MenuLink key={i} to={!!onClick ? '#' : to} onClick={onClick}>
+        {links.map(({ to, label, onClick }) => (
+          <MenuLink key={to} to={!!onClick ? '#' : to} onClick={onClick}>
             {label}
           </MenuLink>
         ))}

--- a/apps/dapp/src/components/Layouts/V2Layout/Footer.tsx
+++ b/apps/dapp/src/components/Layouts/V2Layout/Footer.tsx
@@ -51,12 +51,12 @@ const Footer: React.FC = () => {
   return (
     <FooterContainer>
       <LinkRow>
-        {FooterContent.map((col, i) => (
-          <Links key={i}>
+        {FooterContent.map((col) => (
+          <Links key={col.header}>
             <h4>{col.header}</h4>
             <ul>
-              {col.links.map((link, j) => (
-                <li key={j}>
+              {col.links.map((link) => (
+                <li key={link.text}>
                   <a href={link.link} target="_blank" rel="noreferrer">
                     <FooterImage src={link.image} alt={link.text} />
                     <strong>{link.text}</strong>

--- a/apps/dapp/src/components/Pages/Core/DappPages/Dashboard/Metrics/index.tsx
+++ b/apps/dapp/src/components/Pages/Core/DappPages/Dashboard/Metrics/index.tsx
@@ -24,9 +24,10 @@ const DashboardMetrics = ({ dashboardData }: DashboardMetricsProps) => {
     <>
       <MobileMetricsContainer>
         {sourceData.metrics.map((row, idx) => (
+          // eslint-disable-next-line react/no-array-index-key
           <Fragment key={idx}>
-            {row.map((metric, idx) => (
-              <MobileMetricRow key={idx}>
+            {row.map((metric) => (
+              <MobileMetricRow key={metric.title}>
                 <MobileMetricTitle>{metric.title}</MobileMetricTitle>
                 <MobileMetricValue>{metric.value}</MobileMetricValue>
               </MobileMetricRow>
@@ -37,9 +38,10 @@ const DashboardMetrics = ({ dashboardData }: DashboardMetricsProps) => {
       <MobileMetricsContainer small>
         {sourceData.smallMetrics.map((row, idx) => (
           // TODO: The MobileMetricsContainer for small should be .. smaller
+          // eslint-disable-next-line react/no-array-index-key
           <Fragment key={idx}>
-            {row.map((metric, idx) => (
-              <MobileMetricRow key={idx}>
+            {row.map((metric) => (
+              <MobileMetricRow key={metric.title}>
                 <MobileMetricTitle>{metric.title}</MobileMetricTitle>
                 <MobileMetricValue>{metric.value}</MobileMetricValue>
               </MobileMetricRow>

--- a/apps/dapp/src/components/Pages/Core/DappPages/Dashboard/Table/PaginationControl/PageRangeSelector.tsx
+++ b/apps/dapp/src/components/Pages/Core/DappPages/Dashboard/Table/PaginationControl/PageRangeSelector.tsx
@@ -25,9 +25,9 @@ export const PageRangeSelector = (props: Props) => {
 
   return (
     <>
-      {paginationRange.map((pageNumber, i) => {
+      {paginationRange.map((pageNumber) => {
         if (pageNumber === -1)
-          return <DotsContainer key={i + 'dots'}>...</DotsContainer>;
+          return <DotsContainer key={pageNumber}>...</DotsContainer>;
         return (
           <PageLink
             key={pageNumber}

--- a/apps/dapp/src/components/Pages/Core/DappPages/Dashboard/Table/RowFilterDropdown.tsx
+++ b/apps/dapp/src/components/Pages/Core/DappPages/Dashboard/Table/RowFilterDropdown.tsx
@@ -38,8 +38,8 @@ export const RowFilterDropdown = (props: Props) => {
       <FilterButton onClick={() => setDropdownOpened(!dropdownOpened)} />
       {dropdownOpened && (
         <DropdownOptionsContainer ref={ref}>
-          {dropdownOptions.map((op, idx) => (
-            <DropdownOption key={idx} isChecked={op.checked}>
+          {dropdownOptions.map((op) => (
+            <DropdownOption key={op.label} isChecked={op.checked}>
               <RadioCheckbox
                 id={op.label}
                 defaultChecked={op.checked}

--- a/apps/dapp/src/components/Pages/Core/DappPages/Dashboard/Table/TxnDataTable.tsx
+++ b/apps/dapp/src/components/Pages/Core/DappPages/Dashboard/Table/TxnDataTable.tsx
@@ -90,7 +90,7 @@ export const TxnDataTable = (props: Props) => {
     <DataTable isBiggerThanTablet={isBiggerThanPhone}>
       <thead>
         <HeaderRow>
-          {tableHeaders.map((h, i) => (
+          {tableHeaders.map((h) => (
             <TableHeader
               key={h.name}
               isHidden={h.isHidden}
@@ -205,12 +205,14 @@ const loadSkeletonRows = (
   skeletonColumnsNo: number
 ) => {
   return [...Array(skeletonRowsNo)].map((_, index) => (
+    // eslint-disable-next-line react/no-array-index-key
     <DataRow hasBorderBotton key={index}>
       {[...Array(skeletonColumnsNo)].map(
         (
           _,
           i // Adds x no of loading cells, same as no of table headers
         ) => (
+          // eslint-disable-next-line react/no-array-index-key
           <DataCell key={i}>
             <LoadingText value={loading()} />
           </DataCell>

--- a/apps/dapp/src/components/Pages/Core/NewUI/Home.tsx
+++ b/apps/dapp/src/components/Pages/Core/NewUI/Home.tsx
@@ -210,7 +210,7 @@ const Home = ({ tlc }: { tlc?: boolean }) => {
         {/* Marketing content */}
         <Header>How Does It Work?</Header>
         {MarketingContent.map((content, index) => (
-          <MarketingRow index={index} key={index}>
+          <MarketingRow index={index} key={content.header}>
             <MarketingImage src={content.image} />
             <MarketingTextWrapper>
               <MarketingHeader>{content.header}</MarketingHeader>
@@ -233,11 +233,11 @@ const Home = ({ tlc }: { tlc?: boolean }) => {
       <FooterContainer>
         <LinkRow>
           {FooterContent.map((col, i) => (
-            <Links key={i}>
+            <Links key={col.header}>
               <h4>{col.header}</h4>
               <ul>
                 {col.links.map((link, j) => (
-                  <li key={j}>
+                  <li key={link.text}>
                     <a href={link.link} target="_blank" rel="noreferrer">
                       <FooterImage src={link.image} alt={link.text} />
                       <strong>{link.text}</strong>

--- a/apps/dapp/src/components/Pages/Safe/admin/SafeTxDataTable.tsx
+++ b/apps/dapp/src/components/Pages/Safe/admin/SafeTxDataTable.tsx
@@ -178,12 +178,14 @@ const loadSkeletonRows = (
   skeletonColumnsNo: number
 ) => {
   return [...Array(skeletonRowsNo)].map((_, index) => (
+    // eslint-disable-next-line react/no-array-index-key
     <DataRow hasBorderBotton key={index}>
       {[...Array(skeletonColumnsNo)].map(
         (
           _,
           i // Adds x no of loading cells, same as no of table headers
         ) => (
+          // eslint-disable-next-line react/no-array-index-key
           <DataCell key={i}>
             <LoadingText value={loading()} />
           </DataCell>


### PR DESCRIPTION
# Description

This PR adds the no-array-index-key lint rule, closing the last of the items in #904.

There are a couple places I added `eslint-disable-next-line react/no-array-index-key` because I didn't think it was worth it to try to implement some convoluted key based on the existing data (e.g. rows of metrics). Happy to change if the reviewer think it's worth it.

# Checklist
- [ ] Code follows the style guide
- [ ] I have performed a self-review of my own code
- [ ] New and existing tests pass locally
- [ ] This PR is targeting the correct branch 