### PR TITLE
TGLD audit fix m01

### DIFF
--- a/protocol/contracts/templegold/TempleGold.sol
+++ b/protocol/contracts/templegold/TempleGold.sol
@@ -41,9 +41,6 @@ import { TempleMath } from "contracts/common/TempleMath.sol";
     /// @notice Last block timestamp Temple Gold was minted
     uint32 public override lastMintTimestamp;
 
-    /// @notice Deploy time for first mint amount calculation 
-    uint32 private immutable _deployTime;
-
     //// @notice Distribution as a percentage of 100
     uint256 public constant DISTRIBUTION_DIVISOR = 100 ether;
     /// @notice 1B max supply
@@ -73,7 +70,6 @@ import { TempleMath } from "contracts/common/TempleMath.sol";
        escrow = IDaiGoldAuction(_initArgs.escrow);
        teamGnosis = _initArgs.gnosis;
        _mintChainId = _initArgs.mintChainId;
-       _deployTime = uint32(block.timestamp);
     }
 
     /**
@@ -135,6 +131,8 @@ import { TempleMath } from "contracts/common/TempleMath.sol";
         if (_factor.numerator == 0 || _factor.denominator == 0) { revert CommonEventsAndErrors.ExpectedNonZero(); }
         if (_factor.numerator > _factor.denominator) { revert CommonEventsAndErrors.InvalidParam(); }
         vestingFactor = _factor;
+        /// @dev initialize
+        if (lastMintTimestamp == 0) { lastMintTimestamp = uint32(block.timestamp); }
         emit VestingFactorSet(_factor.numerator, _factor.denominator);
     }
     
@@ -250,13 +248,9 @@ import { TempleMath } from "contracts/common/TempleMath.sol";
     function _getMintAmount(VestingFactor memory vestingFactorCache) private view returns (uint256 mintAmount) {
         uint32 _lastMintTimestamp = lastMintTimestamp;
         uint256 totalSupplyCache = _totalDistributed;
-        /// @notice first time mint
-        if (_lastMintTimestamp == 0) {
-            /// @dev use deployTime for time difference. avoid getting stuck where _lastMintTimestamp is always 0 because mintAmount < 10_000
-            mintAmount = TempleMath.mulDivRound((block.timestamp - _deployTime) * MAX_SUPPLY, vestingFactorCache.numerator, vestingFactorCache.denominator, false);
-        } else {
-            mintAmount = TempleMath.mulDivRound((block.timestamp - _lastMintTimestamp) * (MAX_SUPPLY), vestingFactorCache.numerator, vestingFactorCache.denominator, false);
-        }
+        /// @dev if vesting factor is not set, return 0. `_lastMintTimestamp` is set when vesting factor is set
+        if (_lastMintTimestamp == 0) { return 0; }
+        mintAmount = TempleMath.mulDivRound((block.timestamp - _lastMintTimestamp) * (MAX_SUPPLY), vestingFactorCache.numerator, vestingFactorCache.denominator, false);
        
         if (totalSupplyCache + mintAmount > MAX_SUPPLY) {
             unchecked {


### PR DESCRIPTION
## Title
Misconfiguration of minting TGLD leads to max supply amount being minted too fast

## Description
When minting TGLD through TempleGold contract, the minting amount should be larger than the minimum amount which is 10,000 TGLD. Also if it's the first time that mint happens, the mint amount is always SUPPLY * n/d, which is the amount for one second.

The math above shows that the minting amount per second should be bigger than 10,000 TGLD, which also means that the max supply(1e9 TGLD) gets minted in 1e5 seconds ~ 1day 4hrs.

## Recommendation
When TGLD contract is created or setVestingFactor is called for the first time, it should initialize _lastMintTimestamp

## Tag
Audit Finding M01

Fixes # (issue)

# Checklist
- [ ] Code follows the style guide
- [ ] I have performed a self-review of my own code
- [ ] New and existing tests pass locally
- [ ] This PR is targeting the correct branch 