### PR TITLE
tgld audit fix m02

### DIFF
--- a/protocol/contracts/interfaces/templegold/IAuctionBase.sol
+++ b/protocol/contracts/interfaces/templegold/IAuctionBase.sol
@@ -14,6 +14,7 @@ interface IAuctionBase {
     error InvalidEpoch();
     error AuctionActive();
     error InvalidOperation();
+    error AuctionEnded();
 
     struct EpochInfo {
         /// @notice Start time for epoch

--- a/protocol/contracts/interfaces/templegold/ISpiceAuction.sol
+++ b/protocol/contracts/interfaces/templegold/ISpiceAuction.sol
@@ -13,7 +13,6 @@ interface ISpiceAuction is IAuctionBase {
     error MissingAuctionTokenConfig();
     error NoConfig();
     error RemoveAuctionConfig();
-    error AuctionEnded();
 
     struct SpiceAuctionConfig {
         /// @notice Duration of auction

--- a/protocol/test/forge/templegold/SpiceAuction.t.sol
+++ b/protocol/test/forge/templegold/SpiceAuction.t.sol
@@ -298,7 +298,7 @@ contract SpiceAuctionTest is SpiceAuctionTestBase {
         info = spice.getEpochInfo(currentEpoch);
         // auction ended
         vm.warp(info.endTime);
-        vm.expectRevert(abi.encodeWithSelector(ISpiceAuction.AuctionEnded.selector));
+        vm.expectRevert(abi.encodeWithSelector(IAuctionBase.AuctionEnded.selector));
         spice.removeAuctionConfig();
     }
 


### PR DESCRIPTION
## Title
When recoverToken in DaiGoldAction contract is called, it does not update the status

## Description
recoverToken function moves specific amount of TGLD from the auction contract to another and delete last epoch so that it can be reset and restart.
The tokens get moved but the status nextAuctionGoldAmount is not subtracted, and this gives incorrect amount of TLGD tokens to the next epoch, and as a result, the bidders won't be able to claim their TGLD.

## Recommendation
The nextAuctionGoldAmount should be subtracted when tokens are moved in recoverToken function.

## Tag
tgld audit fix m02

## My Comment(s)
- `nextAuctionGoldAmount` should be updated by addition of leftover amounts instead of subtracting. `nextAuctionGoldAmount` is set to zero in `startAuction`. Also there can be distribution of TGLD after auction start. Added tests to support this. 

Fixes # (issue)

# Checklist
- [ ] Code follows the style guide
- [ ] I have performed a self-review of my own code
- [ ] New and existing tests pass locally
- [ ] This PR is targeting the correct branch 