### PR TITLE
tgld audit fix m03

### DIFF
--- a/protocol/contracts/interfaces/templegold/ITempleGoldStaking.sol
+++ b/protocol/contracts/interfaces/templegold/ITempleGoldStaking.sol
@@ -58,7 +58,7 @@ interface ITempleGoldStaking {
     /// @dev If set to zero, rewards distribution is callable any time 
     function rewardDistributionCoolDown() external view returns (uint160);
     /// @notice Timestamp for last reward notification
-    function lastRewardNotificationTimestamp() external view returns (uint96);
+    function lastRewardDistributionTimestamp() external view returns (uint96);
 
     /// @notice For use when migrating to a new staking contract if TGLD changes.
     function migrator() external view returns (address);

--- a/protocol/contracts/templegold/TempleGoldStaking.sol
+++ b/protocol/contracts/templegold/TempleGoldStaking.sol
@@ -53,7 +53,7 @@ contract TempleGoldStaking is ITempleGoldStaking, TempleElevatedAccess, Pausable
     /// @dev If set to zero, rewards distribution is callable any time 
     uint160 public override rewardDistributionCoolDown;
     /// @notice Timestamp for last reward notification
-    uint96 public override lastRewardNotificationTimestamp;
+    uint96 public override lastRewardDistributionTimestamp;
 
     /// @notice For use when migrating to a new staking contract if TGLD changes.
     address public override migrator;
@@ -246,13 +246,14 @@ contract TempleGoldStaking is ITempleGoldStaking, TempleElevatedAccess, Pausable
         if (distributionStarter != address(0) && msg.sender != distributionStarter) 
             { revert CommonEventsAndErrors.InvalidAccess(); }
         // Mint and distribute TGLD if no cooldown set
-        if (lastRewardNotificationTimestamp + rewardDistributionCoolDown > block.timestamp) 
+        if (lastRewardDistributionTimestamp + rewardDistributionCoolDown > block.timestamp) 
                 { revert CannotDistribute(); }
         _distributeGold();
         uint256 rewardAmount = nextRewardAmount;
         if (rewardAmount == 0 ) { revert CommonEventsAndErrors.ExpectedNonZero(); }
         nextRewardAmount = 0;
         _notifyReward(rewardAmount);
+        lastRewardDistributionTimestamp = uint32(block.timestamp);
     }
 
     /**
@@ -394,7 +395,6 @@ contract TempleGoldStaking is ITempleGoldStaking, TempleElevatedAccess, Pausable
         if (msg.sender != address(rewardToken)) { revert CommonEventsAndErrors.InvalidAccess(); }
         /// @notice Temple Gold contract mints TGLD amount to contract before calling `notifyDistribution`
         nextRewardAmount += amount;
-        lastRewardNotificationTimestamp = uint96(block.timestamp);
         emit GoldDistributionNotified(amount, block.timestamp);
     }
 

--- a/protocol/test/forge/templegold/TempleGoldStaking.t.sol
+++ b/protocol/test/forge/templegold/TempleGoldStaking.t.sol
@@ -299,7 +299,7 @@ contract TempleGoldStakingTest is TempleGoldStakingTestBase {
         staking.distributeRewards();
         uint256 rewardBalance = templeGold.balanceOf(address(staking));
         assertGt(rewardBalance, rewardAmount);
-        assertEq(staking.lastRewardNotificationTimestamp(), block.timestamp);
+        assertEq(staking.lastRewardDistributionTimestamp(), block.timestamp);
         // reward params were set
         uint256 rewardRate = rewardBalance / 7 days;
         ITempleGoldStaking.Reward memory rewardData = staking.getRewardData();
@@ -433,9 +433,8 @@ contract TempleGoldStakingTest is TempleGoldStakingTestBase {
     }
 
     function test_getReward_tgldStaking() public {
-        vm.warp(block.timestamp + 3 days);
-        templeGold.mint();
-        vm.warp(staking.lastRewardNotificationTimestamp() + staking.rewardDistributionCoolDown() + 1);
+        _setVestingFactor(templeGold);
+        skip(1 days);
         staking.distributeRewards();
         
         vm.startPrank(alice);


### PR DESCRIPTION
## Title
In staking contract, rewards distribution can be delayed by front-running distributeGold function

## Description
In TempleGoldStaking contract, the reward distributer calls distributeRewards to by minting available TLGD from the token contract and updates reward rate based on the minted amount.
However, the distribution works only after the distribution cooldown period is passed:
```solidity
if (lastRewardNotificationTimestamp + rewardDistributionCoolDown > block.timestamp) 
    { revert CannotDistribute(); }
```

It uses `lastRewardNotificationTimestamp` as latest updated timestamp, which can be also updated by anyone who calls a public function distributeGold.
By front-running this function, it prevents the distributor from updating reward rate.

More seriously, if distributeGold is called regularly before the distribution cooldown, rewards distribution can be prevented forever.

## Recommendation
Either making distributeGold permissioned or introduce other state variable that represents the latest timestamp of rewards distribution, which is only updated in distributeRewards function.

## Tag
tgld audit fix m03

# Checklist
- [ ] Code follows the style guide
- [ ] I have performed a self-review of my own code
- [ ] New and existing tests pass locally
- [ ] This PR is targeting the correct branch 