### PR TITLE
tgld audit fix m04

### DIFF
--- a/protocol/contracts/templegold/TempleGold.sol
+++ b/protocol/contracts/templegold/TempleGold.sol
@@ -289,6 +289,7 @@ import { TempleMath } from "contracts/common/TempleMath.sol";
         MessagingFee calldata _fee,
         address _refundAddress
     ) external payable virtual override(IOFT, OFTCore) returns (MessagingReceipt memory msgReceipt, OFTReceipt memory oftReceipt) {
+        if (_sendParam.composeMsg.length > 0) { revert CannotCompose(); }
         /// cast bytes32 to address
         address _to = _sendParam.to.bytes32ToAddress();
         /// @dev user can cross-chain transfer to self

--- a/protocol/test/forge/templegold/TempleGoldLayerZero.t.sol
+++ b/protocol/test/forge/templegold/TempleGoldLayerZero.t.sol
@@ -62,16 +62,21 @@ contract TempleGoldLayerZeroTest is TestHelperOz5 {
             tokensToSend,
             tokensToSend,
             options,
-            "",
+            bytes("something"), // compose message
             ""
         );
         MessagingFee memory fee = aTempleGold.quoteSend(sendParam, false);
 
         vm.startPrank(userA);
+        vm.expectRevert(abi.encodeWithSelector(ITempleGold.CannotCompose.selector));
+        aTempleGold.send{ value: fee.nativeFee }(sendParam, fee, payable(address(this)));
+        sendParam.composeMsg = "";
+        
         vm.expectRevert(abi.encodeWithSelector(ITempleGold.NonTransferrable.selector, userA, userB));
         aTempleGold.send{ value: fee.nativeFee }(sendParam, fee, payable(address(this)));
-        
+
         sendParam.to = addressToBytes32(userA);
+
         vm.startPrank(userA);
         aTempleGold.send{ value: fee.nativeFee }(sendParam, fee, payable(address(this)));
         verifyPackets(bEid, addressToBytes32(address(bTempleGold)));


### PR DESCRIPTION
## Title
Configuring compose option will prevent users from receiving TGLD on the destination chain

## Description
Users are able to send their TGLD by calling send function of TempleGold contract.
Since SendParam struct is passed from users, they can add any field including compose data into the message.
However on the destination chain, in _lzReceive function, it blocks messages with compose options in it:
```if (_message.isComposed()) { revert CannotCompose(); }```

This means that users who call send with compose option, they will not receive TGLD tokens on the destination chain.

## Impact
It has Medium severity because token transfer does not work based on the parameter and causes loss of funds for users.

## Recommendation
1. In send function, if the _sendParam includes compose option, it should revert.
2. Even better, send function only inputs mandatory fields from users like the amount to send, and it constructs SendParam in it rather than receiving it as a whole from the user.

## Tag
tgld audit fix m04

# Checklist
- [ ] Code follows the style guide
- [ ] I have performed a self-review of my own code
- [ ] New and existing tests pass locally
- [ ] This PR is targeting the correct branch 