### PR TITLE
tgld audit fix m06

### DIFF
--- a/protocol/contracts/templegold/TempleGoldStaking.sol
+++ b/protocol/contracts/templegold/TempleGoldStaking.sol
@@ -173,8 +173,11 @@ contract TempleGoldStaking is ITempleGoldStaking, TempleElevatedAccess, Pausable
             _delegateBalances[msg.sender] = 0;
             /// @dev if no user delegated to delegate
             /// delegate vote weight will default to vote weight as a user
-            if (delegateBalance > 0) {
-                _updateAccountWeight(msg.sender, delegateBalance, 0, false);
+            uint256 stakeBalance = _balances[msg.sender];
+        
+            if (delegateBalance > 0 && delegateBalance > stakeBalance) {
+                _updateAccountWeight(msg.sender, delegateBalance, stakeBalance, false);
+                /// @dev Do nothing if stakeBalance is larger or same as delegate balance
             }
 
             _delegateUsersSet[msg.sender].clear();


### PR DESCRIPTION
## Title
In staking contract, resetting self delegation will reset vote weight to zero

## Description
In TempleGoldStaking contract, when a delegate resets self delegation, the vote weights delegated to the delegate will be removed by calling _updateAccountWeight.
Since zero is passed as new balance parameter, the stakingTime of vote weight is reset to zero:
// TempleGoldStaking.sol:L580
```solidity
if (_newBalance == 0) {
    t = 0;
    _lastShares = 0;
}
```
This means that the delegate's vote weight starts accumulating from zero even though the delegate has their own balance, which should not be decreased.

## Impact
It has Medium severity because the delegate loses voting power, even becoming zero if resetting self delegation happens right before an epoch ends.

## Recommendation
When resetting self delegation, it should not decrease stakeTime so that delegate's voting power remains based on their own balance

# Checklist
- [ ] Code follows the style guide
- [ ] I have performed a self-review of my own code
- [ ] New and existing tests pass locally
- [ ] This PR is targeting the correct branch 