### PR TITLE
tgld audit fix m07

### DIFF
--- a/protocol/contracts/templegold/SpiceAuction.sol
+++ b/protocol/contracts/templegold/SpiceAuction.sol
@@ -170,7 +170,7 @@ contract SpiceAuction is ISpiceAuction, AuctionBase {
         epochId = _currentEpochId = _currentEpochId + 1;
         EpochInfo storage info = epochs[epochId];
         uint128 startTime = info.startTime = uint128(block.timestamp) + config.startCooldown;
-        uint128 endTime = info.endTime = uint128(block.timestamp) + config.duration;
+        uint128 endTime = info.endTime = startTime + config.duration;
         info.totalAuctionTokenAmount = epochAuctionTokenAmount;
         // Keep track of total allocation auction tokens per epoch
         _totalAuctionTokenAllocation[auctionToken] = totalAuctionTokenAllocation + epochAuctionTokenAmount;


### PR DESCRIPTION
# Title
Incorrect end time setting for spice auction

## Description
In startAuction function of SpiceAuction contract, the end time is set wrong.
```
uint128 startTime = info.startTime = uint128(block.timestamp) + config.startCooldown;
uint128 endTime = info.endTime = uint128(block.timestamp) + config.duration;
```
Currently, endTime is set using block.timestamp, not startTime calculated above.

## Impact
It has Medium severity

## Recommendation
endTime should be calculated using startTime and duration
```
uint128 endTime = info.endTime = startTime + config.duration;
```

## Tag
tgld audit fix m07

# Checklist
- [ ] Code follows the style guide
- [ ] I have performed a self-review of my own code
- [ ] New and existing tests pass locally
- [ ] This PR is targeting the correct branch 