### PR TITLE
tgld audit fix m09

### DIFF
--- a/protocol/contracts/interfaces/templegold/ISpiceAuction.sol
+++ b/protocol/contracts/interfaces/templegold/ISpiceAuction.sol
@@ -90,4 +90,11 @@ interface ISpiceAuction is IAuctionBase {
      * @param _daoExecutor New dao executor
      */
     function setDaoExecutor(address _daoExecutor) external;
+
+    /**
+     * @notice Recover auction tokens for epoch with zero bids
+     * @param epochId Epoch Id
+     * @param to Recipient
+     */
+    function recoverAuctionTokenForZeroBidAuction(uint256 epochId, address to) external;
 }


### PR DESCRIPTION
## Title
No token recover mechanism when the auction ends without any bid

## Description
In SpiceAuction contract, when an auction ends with no bids, the auction tokens are locked into the contract and can't be recovered. recoverToken function doesn't help recover the auction token because it limits recoverable amount to `balance - totalAllocation`

## Impact
It has Medium severity because the auction tokens can be stuck in the contract and can't be recovered, although this would be rare case.

## Recommendation
There has to be a mechanism implemented to recover tokens from auctions when it ends without any bids.

## Tag
tgld audit fix m09

# Checklist
- [ ] Code follows the style guide
- [ ] I have performed a self-review of my own code
- [ ] New and existing tests pass locally
- [ ] This PR is targeting the correct branch 