### PR TITLE
tgld audit fix m10

### DIFF
--- a/protocol/contracts/templegold/TempleGoldStaking.sol
+++ b/protocol/contracts/templegold/TempleGoldStaking.sol
@@ -188,11 +188,11 @@ contract TempleGoldStaking is ITempleGoldStaking, TempleElevatedAccess, Pausable
         address _delegate = userDelegates[msg.sender];
         if (_delegate == address(0)) { revert InvalidDelegate(); }
 
-        _delegateUsersSet[_delegate].remove(msg.sender);
+        bool removed = _delegateUsersSet[_delegate].remove(msg.sender);
         delete userDelegates[msg.sender];
 
         uint256 userBalance = _balances[msg.sender];
-        if (userBalance > 0) {
+        if (userBalance > 0 && removed) {
             // update vote weight of old delegate
             uint256 _prevBalance = _delegateBalances[_delegate];
             uint256 _newDelegateBalance = _delegateBalances[_delegate] = _prevBalance - userBalance;

--- a/protocol/contracts/templegold/TempleGoldStaking.sol
+++ b/protocol/contracts/templegold/TempleGoldStaking.sol
@@ -279,8 +279,8 @@ contract TempleGoldStaking is ITempleGoldStaking, TempleElevatedAccess, Pausable
         _updateAccountWeight(_for, _prevBalance, _balances[_for], true);
         // update delegate weight
         /// @dev this avoids using iteration to get voteWeight for all users delegated to delegate
-        if (userDelegates[_for] != address(0) && userDelegates[_for] != _for) {
-            address delegate = userDelegates[_for];
+        address delegate = userDelegates[_for];
+        if (delegate != address(0) && delegate != _for && delegates[delegate]) {
             /// @dev Reuse variable
             _prevBalance = _delegateBalances[delegate];
             uint256 _newDelegateBalance = _delegateBalances[delegate] = _prevBalance + _amount;
@@ -503,8 +503,8 @@ contract TempleGoldStaking is ITempleGoldStaking, TempleElevatedAccess, Pausable
         /// @dev update account weight as a fallback if delegate for account(if any) is removed in future or user changes delegates
         _updateAccountWeight(staker, _prevBalance, _balances[staker], false);
         /// @dev this avoids using iteration to get voteWeight for all users delegated to delegate
-        if (userDelegates[staker] != address(0) && userDelegates[staker] != staker) {
-            address delegate = userDelegates[staker];
+        address delegate = userDelegates[staker];
+        if (delegate != address(0) && delegate != staker && delegates[delegate]) {
             /// @dev Reuse variable
             _prevBalance = _delegateBalances[delegate];
             /// @dev `_prevBalance > 0` because when a user sets delegate, vote wieght and `_delegateBalance` are updated for delegate

--- a/protocol/test/forge/templegold/TempleGoldStaking.t.sol
+++ b/protocol/test/forge/templegold/TempleGoldStaking.t.sol
@@ -655,12 +655,21 @@ contract TempleGoldStakingTest is TempleGoldStakingTestBase {
         staking.setUserVoteDelegate(mike);
         assertEq(staking.userDelegates(bob), mike);
 
-        // bob can assign to another delegate where previoud delegate is still valid
+        // bob can assign to another delegate where previous delegate is still valid
         vm.startPrank(executor);
         staking.setSelfAsDelegate(true);
         vm.startPrank(bob);
         staking.setUserVoteDelegate(executor);
         assertEq(staking.userDelegates(bob), executor);
+        // bob can stake. old delegate not affected
+        staking.stake(stakeAmount);
+        skip(1 weeks);
+        assertEq(staking.getDelegatedVoteWeight(mike), 0);
+        assertGt(staking.getDelegatedVoteWeight(executor), 0);
+        // bob can withdraw
+        staking.withdrawAll(false);
+        assertEq(staking.getDelegatedVoteWeight(mike), 0);
+        assertEq(staking.getDelegatedVoteWeight(executor), 0);
     }
 
     function test_unsetUserVoteDelegate_remove_delegate_after_self_set_false() public {


### PR DESCRIPTION
## Title
Users can't unset vote delegation after the delegate reset self delegation

## Description
If A sets B as its delegate, _delegateBalances is increased by A's balance.
When B reset self delegation, its _delegateBalances becomes zero.
However when A unsets its delegation from B, it tries to decrease B's _delegateBalances by A's balance.
```solidity
// TempleGoldStaking.sol:L195
if (userBalance > 0) {
    // update vote weight of old delegate
    uint256 _prevBalance = _delegateBalances[_delegate];
    uint256 _newDelegateBalance = _delegateBalances[_delegate] = _prevBalance - userBalance;
    _updateAccountWeight(_delegate, _prevBalance, _newDelegateBalance, false);
}
```
This reverts because _prevBalance is already zero.
As a result A won't be able to unset its delegation from B.

This also happens in withdrawal and stake since in these functions, it does not check if the delegate has self legation enabled.

## Impact
It has High severity because users who delegated their vote power can't get them back, and result in revert in withdraw.

## Recommendation
As implemented in setUserVoteDelegate, it should subtract from B's delegate balance only when remove function returns True which means it's actually removed.

In _stakeFor and withdrawFor function, it should also validate of the delegate has self delegation enabled or not.

## Tag
tgld audit fix m10

# Checklist
- [ ] Code follows the style guide
- [ ] I have performed a self-review of my own code
- [ ] New and existing tests pass locally
- [ ] This PR is targeting the correct branch 