### PR TITLE
tgld audit fix m13

### DIFF
--- a/protocol/contracts/templegold/TempleGoldStaking.sol
+++ b/protocol/contracts/templegold/TempleGoldStaking.sol
@@ -140,7 +140,7 @@ contract TempleGoldStaking is ITempleGoldStaking, TempleElevatedAccess, Pausable
                 // update vote weight of old delegate
                 _prevBalance = _delegateBalances[_userDelegate];
                 /// @dev skip for a previous delegate with 0 users delegated and 0 own vote weight
-                if (_prevBalance > 0) {
+                if (_prevBalance > 0 && _userDelegate != msg.sender) {
                     /// @dev `_prevBalance > 0` because when a user sets delegate, vote weight and `_delegateBalance` are updated for delegate
                     _newDelegateBalance = _delegateBalances[_userDelegate] = _prevBalance - userBalance;
                     _updateAccountWeight(_userDelegate, _prevBalance, _newDelegateBalance, false);

--- a/protocol/test/forge/templegold/TempleGoldStaking.t.sol
+++ b/protocol/test/forge/templegold/TempleGoldStaking.t.sol
@@ -667,28 +667,6 @@ contract TempleGoldStakingTest is TempleGoldStakingTestBase {
         /// @dev see test_stake_delegate_vote_weight and test_withdraw_delegate_vote_weight
     }
 
-    /// @dev commented out. breaks because of wrong getDelegatedVoteWeight(). fixed in other PR
-    // function test_setUserVoteDelegate_from_self_to_other() public {
-    //     _setHalftime(8 weeks);
-    //     deal(address(templeToken), alice, 1000 ether, true);
-    //     vm.startPrank(bob);
-    //     staking.setSelfAsDelegate(true);
-    //     vm.startPrank(alice);
-    //     staking.setSelfAsDelegate(true);
-    //     staking.setUserVoteDelegate(alice);
-    //     vm.warp(block.timestamp * WEEK_LENGTH/ WEEK_LENGTH);
-    //     vm.startPrank(alice);
-    //     _approve(address(templeToken), address(staking), type(uint).max);
-    //     staking.stake(10 ether);
-    //     skip(8 weeks); // still not start of 9th week
-    //     uint256 voteWeight = staking.getDelegatedVoteWeight(alice);
-    //     // changing vote delegate from self(alice) to another user (bob)
-    //     // _delegateBalances should not be decreased
-    //     staking.setUserVoteDelegate(bob);
-    //     skip(1 weeks);
-    //     assertEq(staking.getDelegatedVoteWeight(alice), 0);
-    // }
-
     function test_setUserVoteDelegate() public {
         vm.startPrank(alice);
         vm.expectRevert(abi.encodeWithSelector(CommonEventsAndErrors.InvalidAddress.selector));

--- a/protocol/test/forge/templegold/TempleGoldStaking.t.sol
+++ b/protocol/test/forge/templegold/TempleGoldStaking.t.sol
@@ -667,6 +667,28 @@ contract TempleGoldStakingTest is TempleGoldStakingTestBase {
         /// @dev see test_stake_delegate_vote_weight and test_withdraw_delegate_vote_weight
     }
 
+    /// @dev commented out. breaks because of wrong getDelegatedVoteWeight(). fixed in other PR
+    // function test_setUserVoteDelegate_from_self_to_other() public {
+    //     _setHalftime(8 weeks);
+    //     deal(address(templeToken), alice, 1000 ether, true);
+    //     vm.startPrank(bob);
+    //     staking.setSelfAsDelegate(true);
+    //     vm.startPrank(alice);
+    //     staking.setSelfAsDelegate(true);
+    //     staking.setUserVoteDelegate(alice);
+    //     vm.warp(block.timestamp * WEEK_LENGTH/ WEEK_LENGTH);
+    //     vm.startPrank(alice);
+    //     _approve(address(templeToken), address(staking), type(uint).max);
+    //     staking.stake(10 ether);
+    //     skip(8 weeks); // still not start of 9th week
+    //     uint256 voteWeight = staking.getDelegatedVoteWeight(alice);
+    //     // changing vote delegate from self(alice) to another user (bob)
+    //     // _delegateBalances should not be decreased
+    //     staking.setUserVoteDelegate(bob);
+    //     skip(1 weeks);
+    //     assertEq(staking.getDelegatedVoteWeight(alice), 0);
+    // }
+
     function test_setUserVoteDelegate() public {
         vm.startPrank(alice);
         vm.expectRevert(abi.encodeWithSelector(CommonEventsAndErrors.InvalidAddress.selector));
@@ -675,7 +697,6 @@ contract TempleGoldStakingTest is TempleGoldStakingTestBase {
         vm.expectRevert(abi.encodeWithSelector(ITempleGoldStaking.InvalidDelegate.selector));
         staking.setUserVoteDelegate(bob);
 
-        // vm.startPrank(executor);
         vm.startPrank(bob);
         staking.setSelfAsDelegate(true);
         vm.startPrank(alice);


### PR DESCRIPTION
## Description
In setUserVoteDelegate function, when a user set vote delegator to himeself, his _delegateBalances value doesn't contain his userBalance from L149.
When he changes vote delegator from himself to another user, it subtracts userBalance from _delegateBalances from L145. But it shouldn't subtract userBalance.
```solidity
File: contracts\templegold\TempleGoldStaking.sol
136:         if (userBalance > 0) {
137:             uint256 _prevBalance;
138:             uint256 _newDelegateBalance;
139:             if (removed) {
140:                 // update vote weight of old delegate
141:                 _prevBalance = _delegateBalances[_userDelegate];
142:                 /// @dev skip for a previous delegate with 0 users delegated and 0 own vote weight
143:                 if (_prevBalance > 0) {
144:                     /// @dev `_prevBalance > 0` because when a user sets delegate, vote weight and `_delegateBalance` are updated for delegate
145:                     _newDelegateBalance = _delegateBalances[_userDelegate] = _prevBalance - userBalance;
146:                     _updateAccountWeight(_userDelegate, _prevBalance, _newDelegateBalance, false);
147:                 }
148:             }
149:             if (msg.sender != _delegate) { // @audit msg.sender == _delegate ?
150:                 /// @dev Reuse variables
151:                 _prevBalance = _delegateBalances[_delegate];
152:                 _newDelegateBalance = _delegateBalances[_delegate] = _prevBalance + userBalance;
153:                 _updateAccountWeight(_delegate, _prevBalance, _newDelegateBalance, true);
154:             }
155:         }
```
## Impact
_delegateBalances is not calculated correctly.

## Recommendation
It is recommended to change the following codes:
```solidity
File: contracts\templegold\TempleGoldStaking.sol
        if (removed) {
            // update vote weight of old delegate
            _prevBalance = _delegateBalances[_userDelegate];
            /// @dev skip for a previous delegate with 0 users delegated and 0 own vote weight
-           if (_prevBalance > 0) {
+           if (_prevBalance > 0 && _userDelegate != msg.sender) {
                /// @dev `_prevBalance > 0` because when a user sets delegate, vote weight and `_delegateBalance` are updated for delegate
                _newDelegateBalance = _delegateBalances[_userDelegate] = _prevBalance - userBalance;
                _updateAccountWeight(_userDelegate, _prevBalance, _newDelegateBalance, false);
            }
        }
```

# Checklist
- [ ] Code follows the style guide
- [ ] I have performed a self-review of my own code
- [ ] New and existing tests pass locally
- [ ] This PR is targeting the correct branch 