### PR TITLE
tgld audit fix h15

### DIFF
--- a/protocol/contracts/interfaces/templegold/ITempleGoldStaking.sol
+++ b/protocol/contracts/interfaces/templegold/ITempleGoldStaking.sol
@@ -15,9 +15,13 @@ interface ITempleGoldStaking {
     event HalfTimeSet(uint256 halfTime);
     event VoteDelegateSet(address _delegate, bool _approved);
     event UserDelegateSet(address indexed user, address _delegate);
+    event DelegationPeriodSet(uint32 _minimumPeriod);
 
     error InvalidDelegate();
     error CannotDistribute();
+    error CannotDelegate();
+    error MinimumStakePeriod();
+    error InvalidOperation();
 
     struct Reward {
         uint40 periodFinish;
@@ -30,6 +34,11 @@ interface ITempleGoldStaking {
         uint64 weekNumber;
         uint64 stakeTime;
         uint64 updateTime;
+    }
+
+    struct AccountPreviousWeightParams {
+        AccountWeightParams weight;
+        uint256 balance;
     }
 
     /// @notice The staking token. Temple
@@ -243,4 +252,14 @@ interface ITempleGoldStaking {
     function delegates(address _delegate) external view returns (bool);
     /// @notice Keep track of users and their delegates
     function userDelegates(address _account) external view returns (address);
+
+    /// @notice Minimum time of delegation before reset
+    function delegationPeriod() external view returns (uint32);
+
+    /**
+     * @notice Set minimum time before undelegation. This is also used to check before withdrawal after stake if account is delegated
+     * @param _period Minimum delegation time
+     */
+    function setDelegationPeriod(uint32 _period) external;
+
 }

--- a/protocol/contracts/templegold/TempleGoldStaking.sol
+++ b/protocol/contracts/templegold/TempleGoldStaking.sol
@@ -55,6 +55,9 @@ contract TempleGoldStaking is ITempleGoldStaking, TempleElevatedAccess, Pausable
     /// @notice Timestamp for last reward notification
     uint96 public override lastRewardNotificationTimestamp;
 
+    /// @notice Minimum time of delegation before reset
+    uint32 public override delegationPeriod;
+
     /// @notice For use when migrating to a new staking contract if TGLD changes.
     address public override migrator;
     /// @notice Data struct for rewards
@@ -68,7 +71,7 @@ contract TempleGoldStaking is ITempleGoldStaking, TempleElevatedAccess, Pausable
 
     /// @notice Staker weights for calculating vote weights
     mapping(address account => AccountWeightParams weight) private _weights;
-    mapping(address account => AccountWeightParams weight) private _prevWeights;
+    mapping(address account => AccountPreviousWeightParams weight) private _prevWeights;
     
     /// @notice Delegates
     mapping(address delegate => bool isDelegate) public override delegates;
@@ -78,6 +81,8 @@ contract TempleGoldStaking is ITempleGoldStaking, TempleElevatedAccess, Pausable
     mapping(address account => address delegate) public override userDelegates;
     /// @notice Keep track of delegates and users delegated to them
     mapping(address delegate => ClearableEnumerableSet.ClearableAddressSet) private _delegateUsersSet;
+    /// @notice keep track of user withdraw times
+    mapping(address user => uint256 withdrawTime) public userWithdrawTimes;
 
     constructor(
         address _rescuer,
@@ -122,6 +127,12 @@ contract TempleGoldStaking is ITempleGoldStaking, TempleElevatedAccess, Pausable
     function setUserVoteDelegate(address _delegate) external override {
         if (_delegate == address(0)) { revert CommonEventsAndErrors.InvalidAddress(); }
         if (!delegates[_delegate]) {  revert InvalidDelegate(); }
+        // delegates not allowed to delgate
+        // if you are self delegated as a delegate, you are not allowed to set delegate until reset
+        // total vote counted from governance contracts with own vote weight and delegated vote weight
+        if (delegates[msg.sender]) { revert CannotDelegate(); }
+
+        if (userWithdrawTimes[msg.sender] > block.timestamp) { revert CannotDelegate(); }
 
         // remove old delegate if any
         address _userDelegate = userDelegates[msg.sender];
@@ -140,18 +151,18 @@ contract TempleGoldStaking is ITempleGoldStaking, TempleElevatedAccess, Pausable
                 // update vote weight of old delegate
                 _prevBalance = _delegateBalances[_userDelegate];
                 /// @dev skip for a previous delegate with 0 users delegated and 0 own vote weight
-                if (_prevBalance > 0) {
+                if (_prevBalance > 0 && _userDelegate != msg.sender) {
                     /// @dev `_prevBalance > 0` because when a user sets delegate, vote weight and `_delegateBalance` are updated for delegate
                     _newDelegateBalance = _delegateBalances[_userDelegate] = _prevBalance - userBalance;
                     _updateAccountWeight(_userDelegate, _prevBalance, _newDelegateBalance, false);
                 }
             }
-            if (msg.sender != _delegate) {
-                /// @dev Reuse variables
-                _prevBalance = _delegateBalances[_delegate];
-                _newDelegateBalance = _delegateBalances[_delegate] = _prevBalance + userBalance;
-                _updateAccountWeight(_delegate, _prevBalance, _newDelegateBalance, true);
-            }
+            // setting a new delegate always increases withdraw time by delegation period
+            userWithdrawTimes[msg.sender] = block.timestamp + delegationPeriod;
+            /// @dev Reuse variables
+            _prevBalance = _delegateBalances[_delegate];
+            _newDelegateBalance = _delegateBalances[_delegate] = _prevBalance + userBalance;
+            _updateAccountWeight(_delegate, _prevBalance, _newDelegateBalance, true);
         }
         userDelegates[msg.sender] = _delegate;
         _delegateUsersSet[_delegate].add(msg.sender);
@@ -167,6 +178,8 @@ contract TempleGoldStaking is ITempleGoldStaking, TempleElevatedAccess, Pausable
         bool prevStatusTrue = delegates[msg.sender];
         delegates[msg.sender] = _approve;
         emit VoteDelegateSet(msg.sender, _approve);
+        // unset old delegate
+        if (_approve && userDelegates[msg.sender] != address(0)) { unsetUserVoteDelegate(); }
         // remove delegate vote and reset delegateBalance
         if (!_approve && prevStatusTrue) {
             uint256 delegateBalance = _delegateBalances[msg.sender];
@@ -174,7 +187,12 @@ contract TempleGoldStaking is ITempleGoldStaking, TempleElevatedAccess, Pausable
             /// @dev if no user delegated to delegate
             /// delegate vote weight will default to vote weight as a user
             if (delegateBalance > 0) {
-                _updateAccountWeight(msg.sender, delegateBalance, 0, false);
+                uint256 stakeBalance = _balances[msg.sender];
+                if (delegateBalance > stakeBalance) {
+                    _updateAccountWeight(msg.sender, delegateBalance, stakeBalance, false);
+                } else if (delegateBalance < stakeBalance) {
+                    _updateAccountWeight(msg.sender, delegateBalance, stakeBalance, true);
+                }
             }
 
             _delegateUsersSet[msg.sender].clear();
@@ -184,15 +202,17 @@ contract TempleGoldStaking is ITempleGoldStaking, TempleElevatedAccess, Pausable
     /**  
      * @notice Unset delegate for a user
      */
-    function unsetUserVoteDelegate() external override {
+    function unsetUserVoteDelegate() public override {
         address _delegate = userDelegates[msg.sender];
         if (_delegate == address(0)) { revert InvalidDelegate(); }
 
-        _delegateUsersSet[_delegate].remove(msg.sender);
+        bool removed = _delegateUsersSet[_delegate].remove(msg.sender);
         delete userDelegates[msg.sender];
 
+        if (userWithdrawTimes[msg.sender] > block.timestamp) { revert InvalidOperation(); }
+        userWithdrawTimes[msg.sender] = 0;
         uint256 userBalance = _balances[msg.sender];
-        if (userBalance > 0) {
+        if (userBalance > 0 && removed) {
             // update vote weight of old delegate
             uint256 _prevBalance = _delegateBalances[_delegate];
             uint256 _newDelegateBalance = _delegateBalances[_delegate] = _prevBalance - userBalance;
@@ -221,6 +241,16 @@ contract TempleGoldStaking is ITempleGoldStaking, TempleElevatedAccess, Pausable
         if (_halfTime == 0) { revert CommonEventsAndErrors.ExpectedNonZero(); }
         halfTime = _halfTime;
         emit HalfTimeSet(_halfTime);
+    }
+
+    /**
+     * @notice Set minimum time before undelegation. This is also used to check before withdrawal after stake if account is delegated
+     * @param _period Minimum delegation time
+     */
+    function setDelegationPeriod(uint32 _period) external override onlyElevatedAccess {
+        if (_period == 0) { revert CommonEventsAndErrors.ExpectedNonZero(); }
+        delegationPeriod = _period;
+        emit DelegationPeriodSet(_period);
     }
 
     /**
@@ -279,8 +309,9 @@ contract TempleGoldStaking is ITempleGoldStaking, TempleElevatedAccess, Pausable
         _updateAccountWeight(_for, _prevBalance, _balances[_for], true);
         // update delegate weight
         /// @dev this avoids using iteration to get voteWeight for all users delegated to delegate
-        if (userDelegates[_for] != address(0) && userDelegates[_for] != _for) {
-            address delegate = userDelegates[_for];
+        address delegate = userDelegates[_for];
+        if (delegate != address(0) && delegate != _for && delegates[delegate]) {
+            _updateAccountWithdrawTime(_for, _amount, _balances[_for]);
             /// @dev Reuse variable
             _prevBalance = _delegateBalances[delegate];
             uint256 _newDelegateBalance = _delegateBalances[delegate] = _prevBalance + _amount;
@@ -404,11 +435,7 @@ contract TempleGoldStaking is ITempleGoldStaking, TempleElevatedAccess, Pausable
      * @return Vote weight
      */
     function getDelegatedVoteWeight(address _delegate) external view returns (uint256) {
-        // check address is delegate
-        uint256 ownVoteWeight = _voteWeight(_delegate, _balances[_delegate]);
-        address callerDelegate = userDelegates[_delegate];
-        if (!delegates[_delegate] || callerDelegate == msg.sender) { return ownVoteWeight; }
-        return ownVoteWeight + _voteWeight(_delegate, _delegateBalances[_delegate]);
+        return _voteWeight(_delegate, _delegateBalances[_delegate]);
     }
 
     /**  
@@ -496,15 +523,18 @@ contract TempleGoldStaking is ITempleGoldStaking, TempleElevatedAccess, Pausable
         uint256 _prevBalance = _balances[staker];
         if (_prevBalance < amount) 
             { revert CommonEventsAndErrors.InsufficientBalance(address(stakingToken), amount, _prevBalance); }
+        if (!_canWithdraw(staker)) { revert MinimumStakePeriod(); }
 
         totalSupply -= amount;
-        _balances[staker] = _prevBalance - amount;
+        uint256 stakeBalance = _prevBalance - amount;
+        _balances[staker] = stakeBalance;
+        if (stakeBalance == 0) { delete userWithdrawTimes[staker]; }
 
         /// @dev update account weight as a fallback if delegate for account(if any) is removed in future or user changes delegates
         _updateAccountWeight(staker, _prevBalance, _balances[staker], false);
         /// @dev this avoids using iteration to get voteWeight for all users delegated to delegate
-        if (userDelegates[staker] != address(0) && userDelegates[staker] != staker) {
-            address delegate = userDelegates[staker];
+        address delegate = userDelegates[staker];
+        if (delegate != address(0) && delegate != staker && delegates[delegate]) {
             /// @dev Reuse variable
             _prevBalance = _delegateBalances[delegate];
             /// @dev `_prevBalance > 0` because when a user sets delegate, vote wieght and `_delegateBalance` are updated for delegate
@@ -550,13 +580,10 @@ contract TempleGoldStaking is ITempleGoldStaking, TempleElevatedAccess, Pausable
         /// @dev Vote weights are always evaluated at the end of last week
         /// Borrowed from st-yETH staking contract (https://etherscan.io/address/0x583019fF0f430721aDa9cfb4fac8F06cA104d0B4#code)
         uint256 currentWeek = (block.timestamp / WEEK_LENGTH) - 1;
-        AccountWeightParams storage weight = _weights[_account];
-        uint256 week = uint256(weight.weekNumber);
+        (uint256 week, uint256 t, uint256 updated) = _unpackWeight(_account);
         if (week > currentWeek) {
-            weight = _prevWeights[_account];
+            (week, t, updated, _balance) = _unpackPreviousWeight(_account);
         }
-        uint256 t = weight.stakeTime;
-        uint256 updated = weight.updateTime;
         if (week > 0) {
             t += (block.timestamp / WEEK_LENGTH * WEEK_LENGTH) - updated;
         }
@@ -575,7 +602,13 @@ contract TempleGoldStaking is ITempleGoldStaking, TempleElevatedAccess, Pausable
         (uint256 week, uint256 t, uint256 updated) = _unpackWeight(_account);
         uint256 _lastShares = _prevBalance;
         if (week > 0 && currentWeek > week) {
-            _prevWeights[_account] = weight;
+            AccountPreviousWeightParams storage _prevWeight = _prevWeights[_account];
+            _prevWeight.weight = AccountWeightParams(
+                uint64(week),
+                uint64(t),
+                uint64(updated)
+            );
+            _prevWeight.balance = _prevBalance;
         }
         if (_newBalance == 0) {
             t = 0;
@@ -600,6 +633,38 @@ contract TempleGoldStaking is ITempleGoldStaking, TempleElevatedAccess, Pausable
         week = params.weekNumber;
         t = params.stakeTime;
         updated = params.updateTime;
+    }
+
+    function _packPreviousWeight(AccountWeightParams storage _weight, address _account, uint256 _balance) private {
+        AccountPreviousWeightParams storage _prevWeight = _prevWeights[_account];
+        _prevWeight.weight = AccountWeightParams(
+            _weight.weekNumber,
+            _weight.stakeTime,
+            _weight.updateTime
+        );
+        _prevWeight.balance = _balance;
+    }
+
+    function _unpackPreviousWeight(
+        address _account
+    ) private view returns (uint256 week, uint256 t, uint256 updated, uint256 balance) {
+        AccountPreviousWeightParams memory params = _prevWeights[_account];
+        week = params.weight.weekNumber;
+        t = params.weight.stakeTime;
+        updated = params.weight.updateTime;
+        balance = params.balance;
+    }
+
+    function _updateAccountWithdrawTime(address _account, uint256 _amount, uint256 _newBalance) private {
+        if (userWithdrawTimes[_account] == 0) {
+            userWithdrawTimes[_account] = block.timestamp + delegationPeriod;
+        } else {
+            userWithdrawTimes[_account] = userWithdrawTimes[_account] + delegationPeriod * _amount/ _newBalance;
+        }
+    }
+
+    function _canWithdraw(address _account) private view returns (bool) {
+        return userWithdrawTimes[_account] <= block.timestamp;
     }
 
     modifier updateReward(address _account) {

--- a/protocol/test/forge/templegold/TempleGoldStaking.t.sol
+++ b/protocol/test/forge/templegold/TempleGoldStaking.t.sol
@@ -30,6 +30,7 @@ contract TempleGoldStakingTestBase is TempleGoldCommon {
     event Transfer(address indexed from, address indexed to, uint256 value);
     event VoteDelegateSet(address _delegate, bool _approved);
     event UserDelegateSet(address indexed user, address _delegate);
+    event DelegationPeriodSet(uint32 _minimumPeriod);
 
     IERC20 public bidToken;
     IERC20 public bidToken2;
@@ -93,6 +94,12 @@ contract TempleGoldStakingTestBase is TempleGoldCommon {
         staking.setHalfTime(_halfTime);
         vm.stopPrank();
     }
+    
+    function _setDelegationPeriod(uint32 _period) internal {
+        vm.startPrank(executor);
+        staking.setDelegationPeriod(_period);
+        vm.stopPrank();
+    }
 }
 
 contract TempleGoldStakingAccessTest is TempleGoldStakingTestBase {
@@ -130,6 +137,12 @@ contract TempleGoldStakingAccessTest is TempleGoldStakingTestBase {
         vm.startPrank(unauthorizedUser);
         vm.expectRevert(abi.encodeWithSelector(CommonEventsAndErrors.InvalidAccess.selector));
         staking.unpause();
+    }
+
+    function test_access_setDelegationPeriod() public {
+        vm.startPrank(unauthorizedUser);
+        vm.expectRevert(abi.encodeWithSelector(CommonEventsAndErrors.InvalidAccess.selector));
+        staking.setDelegationPeriod(10 seconds);
     }
 }
 
@@ -198,6 +211,18 @@ contract TempleGoldStakingTest is TempleGoldStakingTestBase {
         emit HalfTimeSet(4 days);
         staking.setHalfTime(4 days);
         assertEq(staking.halfTime(), 4 days);
+    }
+
+    function test_setDelegationPeriod() public {
+        vm.startPrank(executor);
+        vm.expectRevert(abi.encodeWithSelector(CommonEventsAndErrors.ExpectedNonZero.selector));
+        staking.setDelegationPeriod(0);
+
+        uint32 _minimumPeriod = 90 days;
+        vm.expectEmit(address(staking));
+        emit DelegationPeriodSet(_minimumPeriod); 
+        staking.setDelegationPeriod(_minimumPeriod);
+        assertEq(staking.delegationPeriod(), _minimumPeriod);
     }
 
     function test_migrateWithdraw_tgldStaking() public {
@@ -392,44 +417,62 @@ contract TempleGoldStakingTest is TempleGoldStakingTestBase {
     }
 
     function test_stake_tgldStaking() public {
-        _setHalftime(1 days);
+        uint64 halfTime = 4 weeks;
+        _setHalftime(halfTime);
         vm.startPrank(alice);
         vm.expectRevert(abi.encodeWithSelector(CommonEventsAndErrors.ExpectedNonZero.selector));
         staking.stake(0);
 
+        uint256 ts = block.timestamp;
+        // beginning of week
+        uint256 t = ts / WEEK_LENGTH * WEEK_LENGTH;
+        vm.warp(t);
+        uint256 stakeAmount = 1 ether;
         deal(address(templeToken), alice, 100 ether, true);
         _approve(address(templeToken), address(staking), type(uint).max);
         vm.expectEmit(address(staking));
-        emit Staked(alice, 1 ether);
-        staking.stake(1 ether);
-        assertEq(staking.balanceOf(alice), 1 ether);
+        emit Staked(alice, stakeAmount);
+        staking.stake(stakeAmount);
 
-        uint256 ts = block.timestamp ;
-        uint256 t = ts / 7 days * 7 days;
-        uint256 weight = 1 ether * t / (t + 1 days);
+        assertEq(staking.balanceOf(alice), stakeAmount);
+        // uint256 weight = stakeAmount * t / (t + halfTime);
         /// @dev Vote weights are always evaluated at the end of last week
-        assertLt(staking.getVoteWeight(alice), 1 ether);
-        assertEq(staking.getVoteWeight(alice), weight);
+        assertEq(staking.getVoteWeight(alice), 0);
+        // middle of the week. still 0 vote weight. 
+        // reuse variable
+        ts = t + WEEK_LENGTH /2;
+        vm.warp(t);
+        assertEq(staking.getVoteWeight(alice), 0);
+        // beginning of next week
+        t += WEEK_LENGTH;
+        vm.warp(t);
+        assertEq(staking.getVoteWeight(alice), stakeAmount / 5);
+        t += WEEK_LENGTH;
+        vm.warp(t);
+        assertEq(staking.getVoteWeight(alice), stakeAmount / 3);
+        t += WEEK_LENGTH;
+        vm.warp(t);
+        t += WEEK_LENGTH;
+        vm.warp(t);
+        // after 4 weeks (halfTime), vote weight is half of initial stake amount
+        assertEq(staking.getVoteWeight(alice), stakeAmount / 2);
         /// @dev see test_vote_weight for more tests on vote weight
 
         // can stake for others
         vm.startPrank(bob);
         deal(address(templeToken), bob, 100 ether, true);
         _approve(address(templeToken), address(staking), type(uint).max);
+        uint256 newStakeAmount = 10 ether;
         vm.startPrank(executor);
         staking.pause();
         vm.expectRevert(abi.encodeWithSelector(Pausable.EnforcedPause.selector));
-        staking.stakeFor(alice, 10 ether);
+        staking.stakeFor(alice, newStakeAmount);
         staking.unpause();
         vm.startPrank(bob);
         vm.expectEmit(address(staking));
-        emit Staked(alice, 10 ether);
-        staking.stakeFor(alice, 10 ether);
-        assertEq(staking.balanceOf(alice), 11 ether);
-        t += block.timestamp / 7 days * 7 days;
-        weight = 11 ether * t / (t + 1 days);
-        assertGt(staking.getVoteWeight(alice), 1 ether);
-        assertApproxEqAbs(staking.getVoteWeight(alice), weight, 3e15);
+        emit Staked(alice, newStakeAmount);
+        staking.stakeFor(alice, newStakeAmount);
+        assertEq(staking.balanceOf(alice), newStakeAmount+stakeAmount);
     }
 
     function test_getReward_tgldStaking() public {
@@ -451,6 +494,8 @@ contract TempleGoldStakingTest is TempleGoldStakingTestBase {
     }
 
     function test_withdraw_tgldStaking() public {
+        uint64 halfTime = 4 weeks;
+        _setHalftime(halfTime);
         vm.startPrank(alice);
         vm.expectRevert(abi.encodeWithSelector(CommonEventsAndErrors.ExpectedNonZero.selector));
         staking.withdraw(0, true);
@@ -473,6 +518,7 @@ contract TempleGoldStakingTest is TempleGoldStakingTestBase {
         assertEq(staking.getVoteWeight(alice), 0);
         ITempleGoldStaking.AccountWeightParams memory _weight = staking.getAccountWeights(alice);
         assertEq(_weight.updateTime, block.timestamp);
+        assertEq(_weight.stakeTime, 0);
     }
 
     function test_earned_getReward_tgldStaking() public {
@@ -620,8 +666,10 @@ contract TempleGoldStakingTest is TempleGoldStakingTestBase {
 
     function test_setSelfAsDelegate() public {
         vm.startPrank(executor);
-        uint256 halfTime = WEEK_LENGTH / 4;
+        // uint256 halfTime = WEEK_LENGTH / 4;
+        uint256 halfTime = 1 weeks;
         staking.setHalfTime(halfTime);
+        uint256 ts = (block.timestamp / WEEK_LENGTH + 1) * WEEK_LENGTH - halfTime;
 
         vm.startPrank(alice);
         vm.expectEmit(address(staking));
@@ -638,14 +686,20 @@ contract TempleGoldStakingTest is TempleGoldStakingTestBase {
         _approve(address(templeToken), address(staking), type(uint).max);
         staking.stake(stakeAmount);
         // warp to get some vote weight
-        vm.warp(block.timestamp + 1 weeks);
-        assertEq(staking.getDelegatedVoteWeight(alice), staking.getVoteWeight(bob));
+        ts += halfTime;
+        vm.warp(ts);
+        uint256 aliceDelegatedVoteWeight = staking.getDelegatedVoteWeight(alice);
+        assertEq(aliceDelegatedVoteWeight, staking.getVoteWeight(bob));
 
         vm.startPrank(alice);
         vm.expectEmit(address(staking));
         emit VoteDelegateSet(alice, false);
         staking.setSelfAsDelegate(false);
         assertEq(staking.delegates(alice), false);
+        /// @dev vote weights are calculated from previous week
+        assertEq(staking.getDelegatedVoteWeight(alice), aliceDelegatedVoteWeight);
+        ts += WEEK_LENGTH; // following week
+        vm.warp(ts);
         assertEq(staking.getDelegatedVoteWeight(alice), 0);
 
         // bob can assign to another delegate
@@ -655,19 +709,79 @@ contract TempleGoldStakingTest is TempleGoldStakingTestBase {
         staking.setUserVoteDelegate(mike);
         assertEq(staking.userDelegates(bob), mike);
 
-        // bob can assign to another delegate where previoud delegate is still valid
+        // bob can assign to another delegate where previous delegate is still valid
         vm.startPrank(executor);
+        staking.setUserVoteDelegate(mike);
+        assertEq(staking.userDelegates(executor), mike);
         staking.setSelfAsDelegate(true);
+        assertEq(staking.userDelegates(executor), address(0));
         vm.startPrank(bob);
         staking.setUserVoteDelegate(executor);
         assertEq(staking.userDelegates(bob), executor);
+        assertEq(staking.getDelegatedVoteWeight(executor), 0);
+        // bob can stake. old delegate not affected
+        staking.stake(stakeAmount);
+        // has not started accumulating
+        assertEq(staking.getDelegatedVoteWeight(executor), 0);
+        skip(1 weeks);
+        uint256 bobVoteWeight = staking.getVoteWeight(bob);
+        assertEq(staking.getDelegatedVoteWeight(mike), 0);
+        // bob own vote weight greater (started accumulating already)
+        assertGt(bobVoteWeight, staking.getDelegatedVoteWeight(executor));
+        // bob total stake is 2 * stakeAmount = 2 ether. After 1 week, executor vote weight is half
+        assertEq(staking.getDelegatedVoteWeight(executor), stakeAmount);
+        // bob can withdraw
+        staking.withdrawAll(false);
+        assertEq(staking.getDelegatedVoteWeight(mike), 0);
+        // bob vote weight the same. same week
+        assertEq(staking.getVoteWeight(bob), bobVoteWeight);
+        assertEq(staking.getDelegatedVoteWeight(executor), stakeAmount);
+        skip(1 weeks);
+        assertEq(staking.getDelegatedVoteWeight(executor), 0);
+        assertEq(staking.getVoteWeight(bob), 0);
+    }
+
+    function test_unsetUserVoteDelegate_remove_delegate_after_self_set_false() public {
+        vm.startPrank(executor);
+        uint256 halfTime = WEEK_LENGTH / 4;
+        staking.setHalfTime(halfTime);
+
+        vm.startPrank(alice);
+        staking.setSelfAsDelegate(true);
+
+        // bob assigns alice as delegate
+        vm.startPrank(bob);
+        staking.setUserVoteDelegate(alice);
+        // stake
+        uint256 stakeAmount = 1 ether;
+        deal(address(templeToken), bob, 100 ether, true);
+        _approve(address(templeToken), address(staking), type(uint).max);
+        staking.stake(stakeAmount);
+        // warp to get some vote weight
+        skip(1 weeks);
+        uint256 ownVoteWeight = staking.getVoteWeight(bob);
+        assertEq(staking.getVoteWeight(bob), ownVoteWeight);
+        assertEq(staking.getDelegatedVoteWeight(bob), 0);
+        // reset self as delegate
+        vm.startPrank(alice);
+        staking.setSelfAsDelegate(false);
+        assertEq(staking.getVoteWeight(bob), ownVoteWeight);
+        assertEq(staking.getDelegatedVoteWeight(bob), 0);
+
+        // bob unsets delegate
+        vm.startPrank(bob);
+        staking.unsetUserVoteDelegate();
+        assertEq(staking.userDelegated(bob, alice), false);
+        assertEq(staking.userDelegates(bob), address(0));
+        // can withdraw
+        staking.withdrawAll(true);
     }
 
     function test_getDelegatedVoteWeight() public {
         /// @dev see test_stake_delegate_vote_weight and test_withdraw_delegate_vote_weight
     }
 
-    function test_setUserVoteDelegate() public {
+    function test_setUserVoteDelegate_tgldStaking() public {
         vm.startPrank(alice);
         vm.expectRevert(abi.encodeWithSelector(CommonEventsAndErrors.InvalidAddress.selector));
         staking.setUserVoteDelegate(address(0));
@@ -675,22 +789,21 @@ contract TempleGoldStakingTest is TempleGoldStakingTestBase {
         vm.expectRevert(abi.encodeWithSelector(ITempleGoldStaking.InvalidDelegate.selector));
         staking.setUserVoteDelegate(bob);
 
-        // vm.startPrank(executor);
         vm.startPrank(bob);
         staking.setSelfAsDelegate(true);
         vm.startPrank(alice);
         staking.setSelfAsDelegate(true);
+        // caller is already delegate
+        vm.expectRevert(abi.encodeWithSelector(ITempleGoldStaking.CannotDelegate.selector));
+        staking.setUserVoteDelegate(alice);
+        vm.startPrank(mike);
 
         vm.expectEmit(address(staking));
-        emit UserDelegateSet(alice, bob);
+        emit UserDelegateSet(mike, bob);
         staking.setUserVoteDelegate(bob);
 
-        assertEq(staking.userDelegated(alice, bob), true);
-        assertEq(staking.userDelegates(alice), bob);
-
-        // nothing happens. same delegate
-        staking.setUserVoteDelegate(bob);
-        assertEq(staking.userDelegates(alice), bob);
+        assertEq(staking.userDelegated(mike, bob), true);
+        assertEq(staking.userDelegates(mike), bob);
 
         /// @dev see test_stake_delegate_vote_weight for more
 
@@ -698,12 +811,124 @@ contract TempleGoldStakingTest is TempleGoldStakingTestBase {
         vm.startPrank(mike);
         staking.setSelfAsDelegate(true);
         vm.startPrank(alice);
+        staking.setSelfAsDelegate(false);
         vm.expectEmit(address(staking));
         emit UserDelegateSet(alice, mike);
         staking.setUserVoteDelegate(mike);
         assertEq(staking.userDelegated(alice, bob), false);
         assertEq(staking.userDelegated(alice, mike), true);
         assertEq(staking.userDelegates(alice), mike);
+
+        // check user withdraw time
+        uint32 _delegationPeriod = 8 weeks;
+        _setDelegationPeriod(_delegationPeriod);
+        staking.delegationPeriod();
+        vm.startPrank(alice);
+        // alice has 0 stake. so can set vote delegate
+        staking.setUserVoteDelegate(bob);
+        deal(address(templeToken), alice, 500 ether, true);
+        _approve(address(templeToken), address(staking), type(uint).max);
+        // cannot set delegate right after stake because userWithdrawTime updated
+        staking.stake(1 ether);
+        vm.expectRevert(abi.encodeWithSelector(ITempleGoldStaking.CannotDelegate.selector));
+        staking.setUserVoteDelegate(mike);
+        vm.warp(block.timestamp + _delegationPeriod);
+        staking.setUserVoteDelegate(mike);
+        assertEq(staking.userDelegates(alice), mike);
+        // same with unsetUserVoteDelegate
+        vm.expectRevert(abi.encodeWithSelector(ITempleGoldStaking.InvalidOperation.selector));
+        staking.unsetUserVoteDelegate();
+        vm.warp(block.timestamp + _delegationPeriod);
+        staking.unsetUserVoteDelegate();
+        assertEq(staking.userDelegates(alice), address(0));
+    }
+
+    function test_setUserVoteDelegate_unsetUserVoteDelegate_delegationPeriod() public {
+        uint64 _halfTime = 4 weeks;
+        _setHalftime(_halfTime);
+        uint32 _delegationPeriod = 8 weeks;
+        _setDelegationPeriod(_delegationPeriod);
+        vm.startPrank(bob);
+        staking.setSelfAsDelegate(true);
+        vm.startPrank(executor);
+        staking.setSelfAsDelegate(true);
+        vm.startPrank(mike);
+        staking.setUserVoteDelegate(bob);
+        vm.startPrank(alice);
+        staking.setUserVoteDelegate(bob);
+
+        uint256 ts = block.timestamp / WEEK_LENGTH * WEEK_LENGTH;
+        uint256 t = ts;
+        vm.warp(t);
+
+        deal(address(templeToken), alice, 500 ether, true);
+        _approve(address(templeToken), address(staking), type(uint).max);
+        staking.stake(200 ether);
+        uint32 withdrawTime = uint32(block.timestamp + _delegationPeriod);
+        assertEq(staking.userWithdrawTimes(alice), withdrawTime);
+
+        // change delegate after stake
+        vm.expectRevert(abi.encodeWithSelector(ITempleGoldStaking.CannotDelegate.selector));
+        staking.setUserVoteDelegate(executor);
+        // withdraw after stake
+        vm.expectRevert(abi.encodeWithSelector(ITempleGoldStaking.MinimumStakePeriod.selector));
+        staking.withdrawAll(false);
+        t += 5 weeks;
+        vm.warp(t);
+        uint256 nextWithdrawTime = withdrawTime + (_delegationPeriod / 3);
+        staking.stake(100 ether);
+        assertGt(staking.userWithdrawTimes(alice), withdrawTime);
+        assertEq(staking.userWithdrawTimes(alice), nextWithdrawTime);
+        // set to first withdraw time 
+        t = withdrawTime;
+        vm.warp(t);
+        // can't withdraw at old withdraw time
+        vm.expectRevert(abi.encodeWithSelector(ITempleGoldStaking.MinimumStakePeriod.selector));
+        staking.withdrawAll(false);
+        t = nextWithdrawTime;
+        vm.warp(t);
+        uint256 balanceBefore = templeToken.balanceOf(alice);
+        staking.withdrawAll(false);
+        assertEq(templeToken.balanceOf(alice), balanceBefore+300 ether);
+        assertEq(staking.userWithdrawTimes(alice), 0);
+        staking.unsetUserVoteDelegate();
+        
+        // no delegate before stake
+        staking.stake(100 ether);
+        assertEq(staking.userWithdrawTimes(alice), 0);
+        staking.withdrawAll(false);
+        
+        // set delegate before stake
+        staking.setUserVoteDelegate(executor);
+        staking.stake(100 ether);
+        withdrawTime = uint32(block.timestamp + _delegationPeriod);
+        assertEq(staking.userWithdrawTimes(alice), withdrawTime);
+        t = withdrawTime - 1;
+        vm.warp(t);
+        vm.expectRevert(abi.encodeWithSelector(ITempleGoldStaking.MinimumStakePeriod.selector));
+        staking.withdrawAll(false);
+        // set to withdraw time but don't withdraw and set another delegate
+        t += 1;
+        vm.warp(t);
+        staking.setUserVoteDelegate(bob);
+        assertEq(staking.userWithdrawTimes(alice), withdrawTime+_delegationPeriod);
+        t = withdrawTime + _delegationPeriod;
+        vm.warp(t);
+        staking.withdrawAll(false);
+        staking.unsetUserVoteDelegate();
+
+        // stake a few times
+        staking.stake(100 ether);
+        staking.stake(100 ether);
+        // set and unset
+        staking.setUserVoteDelegate(executor);
+        vm.expectRevert(abi.encodeWithSelector(ITempleGoldStaking.InvalidOperation.selector));
+        staking.unsetUserVoteDelegate();
+        vm.expectRevert(abi.encodeWithSelector(ITempleGoldStaking.MinimumStakePeriod.selector));
+        staking.withdrawAll(false);
+        t = staking.userWithdrawTimes(alice);
+        vm.warp(t);
+        staking.withdrawAll(false);
     }
 
     function test_stake_delegate_vote_weight() public {
@@ -756,33 +981,30 @@ contract TempleGoldStakingTest is TempleGoldStakingTestBase {
         // alice change delegate and check vote weight of old delegate
         staking.setUserVoteDelegate(executor);
         // vote weight now of delegate is just from mike
-        assertEq(staking.getDelegatedVoteWeight(bob), stakeAmount * 5 / 6);
+        ts += WEEK_LENGTH;
+        vm.warp(ts);
+        assertEq(staking.getDelegatedVoteWeight(bob), stakeAmount * 9 / 10);
+        assertEq(staking.getVoteWeight(mike), stakeAmount * 9 / 10);
 
         // set delegate to false
-        // vm.startPrank(executor);
         vm.startPrank(bob);
         staking.setSelfAsDelegate(false);
-        assertEq(staking.getDelegatedVoteWeight(bob), 0);
-        assertEq(staking.getVoteWeight(alice), stakeAmount * 5 / 6);
-
-        // alice self delegates and vote weight is not double
-        vm.startPrank(alice);
-        staking.setSelfAsDelegate(true);
-        staking.setUserVoteDelegate(alice);
-        assertEq(staking.userDelegates(alice), alice);
-        assertEq(staking.getDelegatedVoteWeight(alice), stakeAmount * 5 / 6);
-        assertEq(staking.getVoteWeight(alice), stakeAmount * 5 / 6);
+        // same week. using previous week vote weight
+        assertEq(staking.getDelegatedVoteWeight(bob), stakeAmount * 9 / 10);
+        // alice vote weight same increase with increased time
+        assertEq(staking.getVoteWeight(alice), stakeAmount * 9 / 10);
+        // no delegatees 
+        assertEq(staking.getDelegatedVoteWeight(alice), 0);
     }
 
     function test_withdraw_delegate_vote_weight() public {
+        uint64 halfTime = 4 weeks;
+        _setHalftime(halfTime);
+        uint256 ts = block.timestamp / WEEK_LENGTH * WEEK_LENGTH;
         vm.startPrank(bob);
         staking.setSelfAsDelegate(true);
         vm.startPrank(executor);
         staking.setSelfAsDelegate(true);
-        uint256 halfTime = WEEK_LENGTH / 4;
-        staking.setHalfTime(halfTime);
-        // set time to `half_time` before end of a week
-        uint256 ts = (block.timestamp / WEEK_LENGTH + 2) * WEEK_LENGTH - halfTime;
         vm.warp(ts);
 
         vm.startPrank(alice);
@@ -791,7 +1013,8 @@ contract TempleGoldStakingTest is TempleGoldStakingTestBase {
         vm.startPrank(mike);
         staking.setUserVoteDelegate(bob);
         uint256 stakeAmount = 3 ether;
-        // stake
+
+         // stake
         deal(address(templeToken), alice, 100 ether, true);
         deal(address(templeToken), mike, 100 ether, true);
         _approve(address(templeToken), address(staking), type(uint).max);
@@ -800,24 +1023,36 @@ contract TempleGoldStakingTest is TempleGoldStakingTestBase {
         _approve(address(templeToken), address(staking), type(uint).max);
         staking.stake(stakeAmount);
 
-        ts += 2 * halfTime;
+        // warp to halftime
+        ts += WEEK_LENGTH * 4;
         vm.warp(ts);
         assertEq(staking.getVoteWeight(alice), stakeAmount / 2);
-        // delegate weight is 2x (alice + mike)
+        // 2 * stakeAmount is total
         assertEq(staking.getDelegatedVoteWeight(bob), stakeAmount);
 
         // alice withdraws
         staking.withdraw(stakeAmount, true);
-        assertEq(staking.getDelegatedVoteWeight(bob), stakeAmount / 2);
+        // still same week
+        assertEq(staking.getDelegatedVoteWeight(bob), stakeAmount);
+        ts += WEEK_LENGTH;
+        vm.warp(ts);
+        // minus withdraw amount plus 7 days extra vote weights
+        assertEq(staking.getDelegatedVoteWeight(bob), stakeAmount * 5 / 9);
         assertEq(staking.getVoteWeight(alice), 0);
+
         // mike withdraws
         vm.startPrank(mike);
         staking.withdraw(stakeAmount, true);
+        // same week
+        assertEq(staking.getDelegatedVoteWeight(bob), stakeAmount * 5 / 9);
+        assertEq(staking.getVoteWeight(mike), stakeAmount * 5 / 9);
+        ts += WEEK_LENGTH;
+        vm.warp(ts);
         assertEq(staking.getDelegatedVoteWeight(bob), 0);
         assertEq(staking.getVoteWeight(mike), 0);
     }
 
-    function test_unsetUserVoteDelegate() public {
+    function test_unsetUserVoteDelegate_staking() public {
         vm.startPrank(bob);
         staking.setSelfAsDelegate(true);
         vm.startPrank(alice);
@@ -829,6 +1064,7 @@ contract TempleGoldStakingTest is TempleGoldStakingTestBase {
         vm.expectEmit(address(staking));
         emit UserDelegateSet(alice, address(0));
         staking.unsetUserVoteDelegate();
+        assertEq(staking.userDelegates(alice), address(0));
 
         vm.startPrank(executor);
         uint256 halfTime = WEEK_LENGTH / 4;
@@ -850,6 +1086,11 @@ contract TempleGoldStakingTest is TempleGoldStakingTestBase {
         assertEq(staking.getDelegatedVoteWeight(bob), stakeAmount / 2);
 
         staking.unsetUserVoteDelegate();
+        assertEq(staking.userDelegates(alice), address(0));
+        // still same week
+        assertEq(staking.getDelegatedVoteWeight(bob), stakeAmount / 2);
+        ts += WEEK_LENGTH;
+        vm.warp(ts);
         assertEq(staking.getDelegatedVoteWeight(bob), 0);
     }
 }


### PR DESCRIPTION
## Description
When a staker delegates his balance to a delegator, the time duration variable _weights[delegate].stakeTime is decreased. However, when undelegating only the balance is decreased. This makes it possible a malicious user can decrease _weights[delegate].stakeTime. He can expand the impact of this attack by repeating delegating and undelegating.

## Impact
A malicious user can delay the increase of any delegator's voteWeight as much as he wants.

## Recommendation
The mechanism for adjusting the stakingTime between delegation and undelegation should be improved.
Regarding the recommendation, not sure what would be a good solution to prevent repetition of delegation and undelegation to decrease `stakeTime`

## Tag
tgld aucit fix h15

# Checklist
- [ ] Code follows the style guide
- [ ] I have performed a self-review of my own code
- [ ] New and existing tests pass locally
- [ ] This PR is targeting the correct branch 