### PR TITLE
Tgld Audit fix m06

### DIFF
--- a/protocol/contracts/interfaces/templegold/ITempleGoldStaking.sol
+++ b/protocol/contracts/interfaces/templegold/ITempleGoldStaking.sol
@@ -15,9 +15,13 @@ interface ITempleGoldStaking {
     event HalfTimeSet(uint256 halfTime);
     event VoteDelegateSet(address _delegate, bool _approved);
     event UserDelegateSet(address indexed user, address _delegate);
+    event MinimumDelegationPeriodSet(uint32 _minimumPeriod);
 
     error InvalidDelegate();
     error CannotDistribute();
+    error CannotDelegate();
+    error MinimumStakePeriod();
+    error InvalidOperation();
 
     struct Reward {
         uint40 periodFinish;
@@ -30,6 +34,11 @@ interface ITempleGoldStaking {
         uint64 weekNumber;
         uint64 stakeTime;
         uint64 updateTime;
+    }
+
+    struct AccountPreviousWeightParams {
+        AccountWeightParams weight;
+        uint256 balance;
     }
 
     /// @notice The staking token. Temple
@@ -58,7 +67,7 @@ interface ITempleGoldStaking {
     /// @dev If set to zero, rewards distribution is callable any time 
     function rewardDistributionCoolDown() external view returns (uint160);
     /// @notice Timestamp for last reward notification
-    function lastRewardDistributionTimestamp() external view returns (uint96);
+    function lastRewardNotificationTimestamp() external view returns (uint96);
 
     /// @notice For use when migrating to a new staking contract if TGLD changes.
     function migrator() external view returns (address);
@@ -243,4 +252,14 @@ interface ITempleGoldStaking {
     function delegates(address _delegate) external view returns (bool);
     /// @notice Keep track of users and their delegates
     function userDelegates(address _account) external view returns (address);
+
+    /// @notice Minimum time of delegation before reset
+    function minimumDelegationPeriod() external view returns (uint32);
+
+    /**
+     * @notice Set minimum time before undelegation. This is also used to check before withdrawal after stake if account is delegated
+     * @param _minimumPeriod Minimum delegation time
+     */
+    function setDelegationMinimumPeriod(uint32 _minimumPeriod) external;
+
 }

--- a/protocol/contracts/templegold/TempleGoldStaking.sol
+++ b/protocol/contracts/templegold/TempleGoldStaking.sol
@@ -171,13 +171,14 @@ contract TempleGoldStaking is ITempleGoldStaking, TempleElevatedAccess, Pausable
         if (!_approve && prevStatusTrue) {
             uint256 delegateBalance = _delegateBalances[msg.sender];
             _delegateBalances[msg.sender] = 0;
-            /// @dev if no user delegated to delegate
-            /// delegate vote weight will default to vote weight as a user
-            uint256 stakeBalance = _balances[msg.sender];
-        
-            if (delegateBalance > 0 && delegateBalance > stakeBalance) {
-                _updateAccountWeight(msg.sender, delegateBalance, stakeBalance, false);
-                /// @dev Do nothing if stakeBalance is larger or same as delegate balance
+            /// @dev If no user delegated to delegate, `getDelegatedVoteWeight()` will default to 0
+            if (delegateBalance > 0) {
+                uint256 stakeBalance = _balances[msg.sender];
+                if (delegateBalance > stakeBalance) {
+                    _updateAccountWeight(msg.sender, delegateBalance, stakeBalance, false);
+                } else if (delegateBalance < stakeBalance) {
+                    _updateAccountWeight(msg.sender, delegateBalance, stakeBalance, true);
+                }
             }
 
             _delegateUsersSet[msg.sender].clear();

--- a/protocol/contracts/templegold/TempleGoldStaking.sol
+++ b/protocol/contracts/templegold/TempleGoldStaking.sol
@@ -53,7 +53,10 @@ contract TempleGoldStaking is ITempleGoldStaking, TempleElevatedAccess, Pausable
     /// @dev If set to zero, rewards distribution is callable any time 
     uint160 public override rewardDistributionCoolDown;
     /// @notice Timestamp for last reward notification
-    uint96 public override lastRewardDistributionTimestamp;
+    uint96 public override lastRewardNotificationTimestamp;
+
+    /// @notice Minimum time of delegation before reset
+    uint32 public override minimumDelegationPeriod;
 
     /// @notice For use when migrating to a new staking contract if TGLD changes.
     address public override migrator;
@@ -68,7 +71,7 @@ contract TempleGoldStaking is ITempleGoldStaking, TempleElevatedAccess, Pausable
 
     /// @notice Staker weights for calculating vote weights
     mapping(address account => AccountWeightParams weight) private _weights;
-    mapping(address account => AccountWeightParams weight) private _prevWeights;
+    mapping(address account => AccountPreviousWeightParams weight) private _prevWeights;
     
     /// @notice Delegates
     mapping(address delegate => bool isDelegate) public override delegates;
@@ -78,6 +81,8 @@ contract TempleGoldStaking is ITempleGoldStaking, TempleElevatedAccess, Pausable
     mapping(address account => address delegate) public override userDelegates;
     /// @notice Keep track of delegates and users delegated to them
     mapping(address delegate => ClearableEnumerableSet.ClearableAddressSet) private _delegateUsersSet;
+    /// @notice keep track of user withdraw times
+    mapping(address user => uint256 withdrawTime) public userWithdrawTimes;
 
     constructor(
         address _rescuer,
@@ -123,8 +128,13 @@ contract TempleGoldStaking is ITempleGoldStaking, TempleElevatedAccess, Pausable
         if (_delegate == address(0)) { revert CommonEventsAndErrors.InvalidAddress(); }
         if (!delegates[_delegate]) {  revert InvalidDelegate(); }
 
+        if (userWithdrawTimes[msg.sender] > block.timestamp) { revert CannotDelegate(); }
+
         // remove old delegate if any
         address _userDelegate = userDelegates[msg.sender];
+        // any delegatee should not be allowed to delegate
+        // if you are self delegated as a delegate, you are not allowed to set delegate until reset
+        if (_userDelegate == msg.sender) { revert CannotDelegate(); }
         if (_userDelegate == _delegate) { return; }
         ClearableEnumerableSet.ClearableAddressSet storage prevDelegateUsersSet = _delegateUsersSet[_userDelegate];
         uint256 userBalance = _balances[msg.sender];
@@ -140,13 +150,15 @@ contract TempleGoldStaking is ITempleGoldStaking, TempleElevatedAccess, Pausable
                 // update vote weight of old delegate
                 _prevBalance = _delegateBalances[_userDelegate];
                 /// @dev skip for a previous delegate with 0 users delegated and 0 own vote weight
-                if (_prevBalance > 0) {
+                if (_prevBalance > 0 && _userDelegate != msg.sender) {
                     /// @dev `_prevBalance > 0` because when a user sets delegate, vote weight and `_delegateBalance` are updated for delegate
                     _newDelegateBalance = _delegateBalances[_userDelegate] = _prevBalance - userBalance;
                     _updateAccountWeight(_userDelegate, _prevBalance, _newDelegateBalance, false);
                 }
             }
             if (msg.sender != _delegate) {
+                // setting a new delegate always increases withdraw time by delegation period
+                userWithdrawTimes[msg.sender] = block.timestamp + minimumDelegationPeriod;
                 /// @dev Reuse variables
                 _prevBalance = _delegateBalances[_delegate];
                 _newDelegateBalance = _delegateBalances[_delegate] = _prevBalance + userBalance;
@@ -167,6 +179,8 @@ contract TempleGoldStaking is ITempleGoldStaking, TempleElevatedAccess, Pausable
         bool prevStatusTrue = delegates[msg.sender];
         delegates[msg.sender] = _approve;
         emit VoteDelegateSet(msg.sender, _approve);
+        // unset old delegate
+        if (_approve && userDelegates[msg.sender] != address(0)) { unsetUserVoteDelegate(); }
         // remove delegate vote and reset delegateBalance
         if (!_approve && prevStatusTrue) {
             uint256 delegateBalance = _delegateBalances[msg.sender];
@@ -188,13 +202,15 @@ contract TempleGoldStaking is ITempleGoldStaking, TempleElevatedAccess, Pausable
     /**  
      * @notice Unset delegate for a user
      */
-    function unsetUserVoteDelegate() external override {
+    function unsetUserVoteDelegate() public override {
         address _delegate = userDelegates[msg.sender];
         if (_delegate == address(0)) { revert InvalidDelegate(); }
 
         bool removed = _delegateUsersSet[_delegate].remove(msg.sender);
         delete userDelegates[msg.sender];
 
+        if (userWithdrawTimes[msg.sender] > block.timestamp) { revert InvalidOperation(); }
+        userWithdrawTimes[msg.sender] = 0;
         uint256 userBalance = _balances[msg.sender];
         if (userBalance > 0 && removed) {
             // update vote weight of old delegate
@@ -228,6 +244,16 @@ contract TempleGoldStaking is ITempleGoldStaking, TempleElevatedAccess, Pausable
     }
 
     /**
+     * @notice Set minimum time before undelegation. This is also used to check before withdrawal after stake if account is delegated
+     * @param _minimumPeriod Minimum delegation time
+     */
+    function setDelegationMinimumPeriod(uint32 _minimumPeriod) external override onlyElevatedAccess {
+        if (_minimumPeriod == 0) { revert CommonEventsAndErrors.ExpectedNonZero(); }
+        minimumDelegationPeriod = _minimumPeriod;
+        emit MinimumDelegationPeriodSet(_minimumPeriod);
+    }
+
+    /**
       * @notice For migrations to a new staking contract if TGLD changes
       *         1. Withdraw `staker`s tokens to the new staking contract (the migrator)
       *         2. Any existing rewards are claimed and sent directly to the `staker`
@@ -250,14 +276,13 @@ contract TempleGoldStaking is ITempleGoldStaking, TempleElevatedAccess, Pausable
         if (distributionStarter != address(0) && msg.sender != distributionStarter) 
             { revert CommonEventsAndErrors.InvalidAccess(); }
         // Mint and distribute TGLD if no cooldown set
-        if (lastRewardDistributionTimestamp + rewardDistributionCoolDown > block.timestamp) 
+        if (lastRewardNotificationTimestamp + rewardDistributionCoolDown > block.timestamp) 
                 { revert CannotDistribute(); }
         _distributeGold();
         uint256 rewardAmount = nextRewardAmount;
         if (rewardAmount == 0 ) { revert CommonEventsAndErrors.ExpectedNonZero(); }
         nextRewardAmount = 0;
         _notifyReward(rewardAmount);
-        lastRewardDistributionTimestamp = uint32(block.timestamp);
     }
 
     /**
@@ -286,6 +311,7 @@ contract TempleGoldStaking is ITempleGoldStaking, TempleElevatedAccess, Pausable
         /// @dev this avoids using iteration to get voteWeight for all users delegated to delegate
         address delegate = userDelegates[_for];
         if (delegate != address(0) && delegate != _for && delegates[delegate]) {
+            _updateAccountWithdrawTime(_for, _amount, _balances[_for]);
             /// @dev Reuse variable
             _prevBalance = _delegateBalances[delegate];
             uint256 _newDelegateBalance = _delegateBalances[delegate] = _prevBalance + _amount;
@@ -399,6 +425,7 @@ contract TempleGoldStaking is ITempleGoldStaking, TempleElevatedAccess, Pausable
         if (msg.sender != address(rewardToken)) { revert CommonEventsAndErrors.InvalidAccess(); }
         /// @notice Temple Gold contract mints TGLD amount to contract before calling `notifyDistribution`
         nextRewardAmount += amount;
+        lastRewardNotificationTimestamp = uint96(block.timestamp);
         emit GoldDistributionNotified(amount, block.timestamp);
     }
 
@@ -408,11 +435,7 @@ contract TempleGoldStaking is ITempleGoldStaking, TempleElevatedAccess, Pausable
      * @return Vote weight
      */
     function getDelegatedVoteWeight(address _delegate) external view returns (uint256) {
-        // check address is delegate
-        uint256 ownVoteWeight = _voteWeight(_delegate, _balances[_delegate]);
-        address callerDelegate = userDelegates[_delegate];
-        if (!delegates[_delegate] || callerDelegate == msg.sender) { return ownVoteWeight; }
-        return ownVoteWeight + _voteWeight(_delegate, _delegateBalances[_delegate]);
+        return _voteWeight(_delegate, _delegateBalances[_delegate]);
     }
 
     /**  
@@ -500,9 +523,12 @@ contract TempleGoldStaking is ITempleGoldStaking, TempleElevatedAccess, Pausable
         uint256 _prevBalance = _balances[staker];
         if (_prevBalance < amount) 
             { revert CommonEventsAndErrors.InsufficientBalance(address(stakingToken), amount, _prevBalance); }
+        if (!_canWithdraw(staker)) { revert MinimumStakePeriod(); }
 
         totalSupply -= amount;
-        _balances[staker] = _prevBalance - amount;
+        uint256 stakeBalance = _prevBalance - amount;
+        _balances[staker] = stakeBalance;
+        if (stakeBalance == 0) { delete userWithdrawTimes[staker]; }
 
         /// @dev update account weight as a fallback if delegate for account(if any) is removed in future or user changes delegates
         _updateAccountWeight(staker, _prevBalance, _balances[staker], false);
@@ -554,13 +580,10 @@ contract TempleGoldStaking is ITempleGoldStaking, TempleElevatedAccess, Pausable
         /// @dev Vote weights are always evaluated at the end of last week
         /// Borrowed from st-yETH staking contract (https://etherscan.io/address/0x583019fF0f430721aDa9cfb4fac8F06cA104d0B4#code)
         uint256 currentWeek = (block.timestamp / WEEK_LENGTH) - 1;
-        AccountWeightParams storage weight = _weights[_account];
-        uint256 week = uint256(weight.weekNumber);
+        (uint256 week, uint256 t, uint256 updated) = _unpackWeight(_account);
         if (week > currentWeek) {
-            weight = _prevWeights[_account];
+            (week, t, updated, _balance) = _unpackPreviousWeight(_account);
         }
-        uint256 t = weight.stakeTime;
-        uint256 updated = weight.updateTime;
         if (week > 0) {
             t += (block.timestamp / WEEK_LENGTH * WEEK_LENGTH) - updated;
         }
@@ -579,7 +602,13 @@ contract TempleGoldStaking is ITempleGoldStaking, TempleElevatedAccess, Pausable
         (uint256 week, uint256 t, uint256 updated) = _unpackWeight(_account);
         uint256 _lastShares = _prevBalance;
         if (week > 0 && currentWeek > week) {
-            _prevWeights[_account] = weight;
+            AccountPreviousWeightParams storage _prevWeight = _prevWeights[_account];
+            _prevWeight.weight = AccountWeightParams(
+                uint64(week),
+                uint64(t),
+                uint64(updated)
+            );
+            _prevWeight.balance = _prevBalance;
         }
         if (_newBalance == 0) {
             t = 0;
@@ -604,6 +633,28 @@ contract TempleGoldStaking is ITempleGoldStaking, TempleElevatedAccess, Pausable
         week = params.weekNumber;
         t = params.stakeTime;
         updated = params.updateTime;
+    }
+
+    function _unpackPreviousWeight(
+        address _account
+    ) private view returns (uint256 week, uint256 t, uint256 updated, uint256 balance) {
+        AccountPreviousWeightParams memory params = _prevWeights[_account];
+        week = params.weight.weekNumber;
+        t = params.weight.stakeTime;
+        updated = params.weight.updateTime;
+        balance = params.balance;
+    }
+
+    function _updateAccountWithdrawTime(address _account, uint256 _amount, uint256 _newBalance) private {
+        if (userWithdrawTimes[_account] == 0) {
+            userWithdrawTimes[_account] = block.timestamp + minimumDelegationPeriod;
+        } else {
+            userWithdrawTimes[_account] = userWithdrawTimes[_account] + minimumDelegationPeriod * _amount/ _newBalance;
+        }
+    }
+
+    function _canWithdraw(address _account) private view returns (bool) {
+        return userWithdrawTimes[_account] <= block.timestamp;
     }
 
     modifier updateReward(address _account) {

--- a/protocol/test/forge/templegold/TempleGoldStaking.t.sol
+++ b/protocol/test/forge/templegold/TempleGoldStaking.t.sol
@@ -30,6 +30,7 @@ contract TempleGoldStakingTestBase is TempleGoldCommon {
     event Transfer(address indexed from, address indexed to, uint256 value);
     event VoteDelegateSet(address _delegate, bool _approved);
     event UserDelegateSet(address indexed user, address _delegate);
+    event MinimumDelegationPeriodSet(uint32 _minimumPeriod);
 
     IERC20 public bidToken;
     IERC20 public bidToken2;
@@ -93,6 +94,12 @@ contract TempleGoldStakingTestBase is TempleGoldCommon {
         staking.setHalfTime(_halfTime);
         vm.stopPrank();
     }
+    
+    function _setMinimumDelegationPeriod(uint32 _period) internal {
+        vm.startPrank(executor);
+        staking.setDelegationMinimumPeriod(_period);
+        vm.stopPrank();
+    }
 }
 
 contract TempleGoldStakingAccessTest is TempleGoldStakingTestBase {
@@ -130,6 +137,12 @@ contract TempleGoldStakingAccessTest is TempleGoldStakingTestBase {
         vm.startPrank(unauthorizedUser);
         vm.expectRevert(abi.encodeWithSelector(CommonEventsAndErrors.InvalidAccess.selector));
         staking.unpause();
+    }
+
+    function test_access_setDelegationMinimumPeriod() public {
+        vm.startPrank(unauthorizedUser);
+        vm.expectRevert(abi.encodeWithSelector(CommonEventsAndErrors.InvalidAccess.selector));
+        staking.setDelegationMinimumPeriod(10 seconds);
     }
 }
 
@@ -198,6 +211,18 @@ contract TempleGoldStakingTest is TempleGoldStakingTestBase {
         emit HalfTimeSet(4 days);
         staking.setHalfTime(4 days);
         assertEq(staking.halfTime(), 4 days);
+    }
+
+    function test_setDelegationMinimumPeriod() public {
+        vm.startPrank(executor);
+        vm.expectRevert(abi.encodeWithSelector(CommonEventsAndErrors.ExpectedNonZero.selector));
+        staking.setDelegationMinimumPeriod(0);
+
+        uint32 _minimumPeriod = 90 days;
+        vm.expectEmit(address(staking));
+        emit MinimumDelegationPeriodSet(_minimumPeriod); 
+        staking.setDelegationMinimumPeriod(_minimumPeriod);
+        assertEq(staking.minimumDelegationPeriod(), _minimumPeriod);
     }
 
     function test_migrateWithdraw_tgldStaking() public {
@@ -299,7 +324,7 @@ contract TempleGoldStakingTest is TempleGoldStakingTestBase {
         staking.distributeRewards();
         uint256 rewardBalance = templeGold.balanceOf(address(staking));
         assertGt(rewardBalance, rewardAmount);
-        assertEq(staking.lastRewardDistributionTimestamp(), block.timestamp);
+        assertEq(staking.lastRewardNotificationTimestamp(), block.timestamp);
         // reward params were set
         uint256 rewardRate = rewardBalance / 7 days;
         ITempleGoldStaking.Reward memory rewardData = staking.getRewardData();
@@ -392,49 +417,68 @@ contract TempleGoldStakingTest is TempleGoldStakingTestBase {
     }
 
     function test_stake_tgldStaking() public {
-        _setHalftime(1 days);
+        uint64 halfTime = 4 weeks;
+        _setHalftime(halfTime);
         vm.startPrank(alice);
         vm.expectRevert(abi.encodeWithSelector(CommonEventsAndErrors.ExpectedNonZero.selector));
         staking.stake(0);
 
+        uint256 ts = block.timestamp;
+        // beginning of week
+        uint256 t = ts / WEEK_LENGTH * WEEK_LENGTH;
+        vm.warp(t);
+        uint256 stakeAmount = 1 ether;
         deal(address(templeToken), alice, 100 ether, true);
         _approve(address(templeToken), address(staking), type(uint).max);
         vm.expectEmit(address(staking));
-        emit Staked(alice, 1 ether);
-        staking.stake(1 ether);
-        assertEq(staking.balanceOf(alice), 1 ether);
+        emit Staked(alice, stakeAmount);
+        staking.stake(stakeAmount);
 
-        uint256 ts = block.timestamp ;
-        uint256 t = ts / 7 days * 7 days;
-        uint256 weight = 1 ether * t / (t + 1 days);
+        assertEq(staking.balanceOf(alice), stakeAmount);
+        // uint256 weight = stakeAmount * t / (t + halfTime);
         /// @dev Vote weights are always evaluated at the end of last week
-        assertLt(staking.getVoteWeight(alice), 1 ether);
-        assertEq(staking.getVoteWeight(alice), weight);
+        assertEq(staking.getVoteWeight(alice), 0);
+        // middle of the week. still 0 vote weight. 
+        // reuse variable
+        ts = t + WEEK_LENGTH /2;
+        vm.warp(t);
+        assertEq(staking.getVoteWeight(alice), 0);
+        // beginning of next week
+        t += WEEK_LENGTH;
+        vm.warp(t);
+        assertEq(staking.getVoteWeight(alice), stakeAmount / 5);
+        t += WEEK_LENGTH;
+        vm.warp(t);
+        assertEq(staking.getVoteWeight(alice), stakeAmount / 3);
+        t += WEEK_LENGTH;
+        vm.warp(t);
+        t += WEEK_LENGTH;
+        vm.warp(t);
+        // after 4 weeks (halfTime), vote weight is half of initial stake amount
+        assertEq(staking.getVoteWeight(alice), stakeAmount / 2);
         /// @dev see test_vote_weight for more tests on vote weight
 
         // can stake for others
         vm.startPrank(bob);
         deal(address(templeToken), bob, 100 ether, true);
         _approve(address(templeToken), address(staking), type(uint).max);
+        uint256 newStakeAmount = 10 ether;
         vm.startPrank(executor);
         staking.pause();
         vm.expectRevert(abi.encodeWithSelector(Pausable.EnforcedPause.selector));
-        staking.stakeFor(alice, 10 ether);
+        staking.stakeFor(alice, newStakeAmount);
         staking.unpause();
         vm.startPrank(bob);
         vm.expectEmit(address(staking));
-        emit Staked(alice, 10 ether);
-        staking.stakeFor(alice, 10 ether);
-        assertEq(staking.balanceOf(alice), 11 ether);
-        t += block.timestamp / 7 days * 7 days;
-        weight = 11 ether * t / (t + 1 days);
-        assertGt(staking.getVoteWeight(alice), 1 ether);
-        assertApproxEqAbs(staking.getVoteWeight(alice), weight, 3e15);
+        emit Staked(alice, newStakeAmount);
+        staking.stakeFor(alice, newStakeAmount);
+        assertEq(staking.balanceOf(alice), newStakeAmount+stakeAmount);
     }
 
     function test_getReward_tgldStaking() public {
-        _setVestingFactor(templeGold);
-        skip(1 days);
+        vm.warp(block.timestamp + 3 days);
+        templeGold.mint();
+        vm.warp(staking.lastRewardNotificationTimestamp() + staking.rewardDistributionCoolDown() + 1);
         staking.distributeRewards();
         
         vm.startPrank(alice);
@@ -450,6 +494,8 @@ contract TempleGoldStakingTest is TempleGoldStakingTestBase {
     }
 
     function test_withdraw_tgldStaking() public {
+        uint64 halfTime = 4 weeks;
+        _setHalftime(halfTime);
         vm.startPrank(alice);
         vm.expectRevert(abi.encodeWithSelector(CommonEventsAndErrors.ExpectedNonZero.selector));
         staking.withdraw(0, true);
@@ -472,6 +518,7 @@ contract TempleGoldStakingTest is TempleGoldStakingTestBase {
         assertEq(staking.getVoteWeight(alice), 0);
         ITempleGoldStaking.AccountWeightParams memory _weight = staking.getAccountWeights(alice);
         assertEq(_weight.updateTime, block.timestamp);
+        assertEq(_weight.stakeTime, 0);
     }
 
     function test_earned_getReward_tgldStaking() public {
@@ -619,8 +666,9 @@ contract TempleGoldStakingTest is TempleGoldStakingTestBase {
 
     function test_setSelfAsDelegate() public {
         vm.startPrank(executor);
-        uint256 halfTime = WEEK_LENGTH / 4;
+        uint256 halfTime = 1 weeks;
         staking.setHalfTime(halfTime);
+        uint256 ts = (block.timestamp / WEEK_LENGTH + 1) * WEEK_LENGTH - halfTime; 
 
         vm.startPrank(alice);
         vm.expectEmit(address(staking));
@@ -637,25 +685,21 @@ contract TempleGoldStakingTest is TempleGoldStakingTestBase {
         _approve(address(templeToken), address(staking), type(uint).max);
         staking.stake(stakeAmount);
         // warp to get some vote weight
-        vm.warp(block.timestamp + 1 weeks);
-        assertEq(staking.getDelegatedVoteWeight(alice), staking.getVoteWeight(bob));
+        ts += halfTime;
+        vm.warp(ts);
+        uint256 aliceDelegatedVoteWeight = staking.getDelegatedVoteWeight(alice);
+        assertEq(aliceDelegatedVoteWeight, staking.getVoteWeight(bob));
 
-        // alice stakes before reset delegate status
         vm.startPrank(alice);
-        deal(address(templeToken), alice, 100 ether, true);
-        _approve(address(templeToken), address(staking), type(uint).max);
-        staking.stake(stakeAmount);
-        skip(1 weeks);
-        assertGt(staking.getVoteWeight(alice), 0);
-        uint256 aliceVoteWeight = staking.getVoteWeight(alice);
-
         vm.expectEmit(address(staking));
         emit VoteDelegateSet(alice, false);
         staking.setSelfAsDelegate(false);
         assertEq(staking.delegates(alice), false);
-        // both alice own vote weight and delegated vote weight are same after reset delegate status
-        assertEq(staking.getDelegatedVoteWeight(alice), aliceVoteWeight);
-        assertEq(aliceVoteWeight, staking.getVoteWeight(alice));
+        /// @dev vote weights are calculated from previous week
+        assertEq(staking.getDelegatedVoteWeight(alice), aliceDelegatedVoteWeight);
+        ts += WEEK_LENGTH; // following week
+        vm.warp(ts);
+        assertEq(staking.getDelegatedVoteWeight(alice), 0);
 
         // bob can assign to another delegate
         vm.startPrank(mike);
@@ -663,11 +707,6 @@ contract TempleGoldStakingTest is TempleGoldStakingTestBase {
         vm.startPrank(bob);
         staking.setUserVoteDelegate(mike);
         assertEq(staking.userDelegates(bob), mike);
-        // delegate balance was 0 at start
-        vm.startPrank(mike);
-        staking.setSelfAsDelegate(false);
-        assertEq(staking.getDelegatedVoteWeight(mike), 0);
-        assertEq(staking.getVoteWeight(mike), 0);
 
         // bob can assign to another delegate where previous delegate is still valid
         vm.startPrank(executor);
@@ -675,15 +714,54 @@ contract TempleGoldStakingTest is TempleGoldStakingTestBase {
         vm.startPrank(bob);
         staking.setUserVoteDelegate(executor);
         assertEq(staking.userDelegates(bob), executor);
+        assertEq(staking.getDelegatedVoteWeight(executor), 0);
         // bob can stake. old delegate not affected
         staking.stake(stakeAmount);
+        // has not started accumulating
+        assertEq(staking.getDelegatedVoteWeight(executor), 0);
         skip(1 weeks);
+        uint256 bobVoteWeight = staking.getVoteWeight(bob);
         assertEq(staking.getDelegatedVoteWeight(mike), 0);
-        assertGt(staking.getDelegatedVoteWeight(executor), 0);
+        // bob own vote weight greater (started accumulating already)
+        assertGt(bobVoteWeight, staking.getDelegatedVoteWeight(executor));
+        // bob total stake is 2 * stakeAmount = 2 ether. After 1 week, executor vote weight is half
+        assertEq(staking.getDelegatedVoteWeight(executor), stakeAmount);
         // bob can withdraw
         staking.withdrawAll(false);
         assertEq(staking.getDelegatedVoteWeight(mike), 0);
+        // bob vote weight the same. same week
+        assertEq(staking.getVoteWeight(bob), bobVoteWeight);
+        assertEq(staking.getDelegatedVoteWeight(executor), stakeAmount);
+        skip(1 weeks);
         assertEq(staking.getDelegatedVoteWeight(executor), 0);
+        assertEq(staking.getVoteWeight(bob), 0);
+    }
+
+    function test_setSelfAsDelegate_user_weight_same_after_resetDelegation() public {
+        uint64 _halfTime = 4 weeks;
+        _setHalftime(_halfTime);
+        uint256 ts = block.timestamp / WEEK_LENGTH * WEEK_LENGTH;
+        vm.warp(ts);
+        vm.startPrank(alice);
+        deal(address(templeToken), alice, 100 ether, true);
+        deal(address(templeToken), mike, 100 ether, true);
+        _approve(address(templeToken), address(staking), type(uint).max);
+        uint256 stakeAmount = 1 ether;
+        staking.stake(stakeAmount);
+        staking.setSelfAsDelegate(true);
+        vm.startPrank(mike);
+        _approve(address(templeToken), address(staking), type(uint).max);
+        staking.setUserVoteDelegate(alice);
+        staking.stake(stakeAmount);
+        ts += 4 weeks;
+        vm.warp(ts);
+        uint256 aliceVoteWeight = staking.getVoteWeight(alice);
+        assertEq(aliceVoteWeight, staking.getDelegatedVoteWeight(alice));
+        // reset delegation but own vote weight is not affected
+        vm.startPrank(alice);
+        staking.setSelfAsDelegate(false);
+        assertEq(staking.getVoteWeight(alice), aliceVoteWeight);
+        assertEq(staking.getDelegatedVoteWeight(alice), 0);
     }
 
     function test_unsetUserVoteDelegate_remove_delegate_after_self_set_false() public {
@@ -706,13 +784,12 @@ contract TempleGoldStakingTest is TempleGoldStakingTestBase {
         skip(1 weeks);
         uint256 ownVoteWeight = staking.getVoteWeight(bob);
         assertEq(staking.getVoteWeight(bob), ownVoteWeight);
-        assertEq(staking.getDelegatedVoteWeight(bob), ownVoteWeight);
+        assertEq(staking.getDelegatedVoteWeight(bob), 0);
         // reset self as delegate
         vm.startPrank(alice);
         staking.setSelfAsDelegate(false);
         assertEq(staking.getVoteWeight(bob), ownVoteWeight);
-        // uses own weight
-        assertEq(staking.getDelegatedVoteWeight(bob), ownVoteWeight);
+        assertEq(staking.getDelegatedVoteWeight(bob), 0);
 
         // bob unsets delegate
         vm.startPrank(bob);
@@ -735,12 +812,11 @@ contract TempleGoldStakingTest is TempleGoldStakingTestBase {
         vm.expectRevert(abi.encodeWithSelector(ITempleGoldStaking.InvalidDelegate.selector));
         staking.setUserVoteDelegate(bob);
 
-        // vm.startPrank(executor);
         vm.startPrank(bob);
         staking.setSelfAsDelegate(true);
         vm.startPrank(alice);
         staking.setSelfAsDelegate(true);
-
+        // todo check CannotDelegate() error
         vm.expectEmit(address(staking));
         emit UserDelegateSet(alice, bob);
         staking.setUserVoteDelegate(bob);
@@ -764,6 +840,172 @@ contract TempleGoldStakingTest is TempleGoldStakingTestBase {
         assertEq(staking.userDelegated(alice, bob), false);
         assertEq(staking.userDelegated(alice, mike), true);
         assertEq(staking.userDelegates(alice), mike);
+    }
+
+    function test_setUserVoteDelegate_unsetUserVoteDelegate_delegationPeriod() public {
+        uint64 _halfTime = 4 weeks;
+        _setHalftime(_halfTime);
+        uint32 _delegationPeriod = 8 weeks;
+        _setMinimumDelegationPeriod(_delegationPeriod);
+        vm.startPrank(bob);
+        staking.setSelfAsDelegate(true);
+        vm.startPrank(executor);
+        staking.setSelfAsDelegate(true);
+        vm.startPrank(mike);
+        staking.setUserVoteDelegate(bob);
+        vm.startPrank(alice);
+        staking.setUserVoteDelegate(bob);
+
+        uint256 ts = block.timestamp / WEEK_LENGTH * WEEK_LENGTH;
+        uint256 t = ts;
+        vm.warp(t);
+
+        deal(address(templeToken), alice, 500 ether, true);
+        _approve(address(templeToken), address(staking), type(uint).max);
+        staking.stake(200 ether);
+        uint32 withdrawTime = uint32(block.timestamp + _delegationPeriod);
+        assertEq(staking.userWithdrawTimes(alice), withdrawTime);
+
+        // change delegate after stake
+        vm.expectRevert(abi.encodeWithSelector(ITempleGoldStaking.CannotDelegate.selector));
+        staking.setUserVoteDelegate(executor);
+        // withdraw after stake
+        vm.expectRevert(abi.encodeWithSelector(ITempleGoldStaking.MinimumStakePeriod.selector));
+        staking.withdrawAll(false);
+        t += 5 weeks;
+        vm.warp(t);
+        uint256 nextWithdrawTime = withdrawTime + (_delegationPeriod / 3);
+        staking.stake(100 ether);
+        assertGt(staking.userWithdrawTimes(alice), withdrawTime);
+        assertEq(staking.userWithdrawTimes(alice), nextWithdrawTime);
+        // set to first withdraw time 
+        t = withdrawTime;
+        vm.warp(t);
+        // can't withdraw at old withdraw time
+        vm.expectRevert(abi.encodeWithSelector(ITempleGoldStaking.MinimumStakePeriod.selector));
+        staking.withdrawAll(false);
+        t = nextWithdrawTime;
+        vm.warp(t);
+        uint256 balanceBefore = templeToken.balanceOf(alice);
+        staking.withdrawAll(false);
+        assertEq(templeToken.balanceOf(alice), balanceBefore+300 ether);
+        assertEq(staking.userWithdrawTimes(alice), 0);
+        staking.unsetUserVoteDelegate();
+        
+        // no delegate before stake
+        staking.stake(100 ether);
+        assertEq(staking.userWithdrawTimes(alice), 0);
+        staking.withdrawAll(false);
+        
+        // set delegate before stake
+        staking.setUserVoteDelegate(executor);
+        staking.stake(100 ether);
+        withdrawTime = uint32(block.timestamp + _delegationPeriod);
+        assertEq(staking.userWithdrawTimes(alice), withdrawTime);
+        t = withdrawTime - 1;
+        vm.warp(t);
+        vm.expectRevert(abi.encodeWithSelector(ITempleGoldStaking.MinimumStakePeriod.selector));
+        staking.withdrawAll(false);
+        // set to withdraw time but don't withdraw and set another delegate
+        t += 1;
+        vm.warp(t);
+        staking.setUserVoteDelegate(bob);
+        assertEq(staking.userWithdrawTimes(alice), withdrawTime+_delegationPeriod);
+        t = withdrawTime + _delegationPeriod;
+        vm.warp(t);
+        staking.withdrawAll(false);
+        staking.unsetUserVoteDelegate();
+
+        // stake a few times
+        staking.stake(100 ether);
+        staking.stake(100 ether);
+        // set and unset
+        staking.setUserVoteDelegate(executor);
+        vm.expectRevert(abi.encodeWithSelector(ITempleGoldStaking.InvalidOperation.selector));
+        staking.unsetUserVoteDelegate();
+        vm.expectRevert(abi.encodeWithSelector(ITempleGoldStaking.MinimumStakePeriod.selector));
+        staking.withdrawAll(false);
+        t = staking.userWithdrawTimes(alice);
+        vm.warp(t);
+        staking.withdrawAll(false);
+    }
+
+    function test_check_finding_15() public {
+        uint64 _halfTime = 7 days;
+        _setHalftime(_halfTime);
+        vm.startPrank(bob);
+        staking.setSelfAsDelegate(true);
+        // vm.startPrank(mike);
+        // staking.setUserVoteDelegate(bob);
+        vm.startPrank(alice);
+        staking.setUserVoteDelegate(bob);
+        uint256 ts = block.timestamp / WEEK_LENGTH * WEEK_LENGTH;
+        uint256 t = ts;
+        vm.warp(t);
+        deal(address(templeToken), alice, 200 ether, true);
+        deal(address(templeToken), mike, 200 ether, true);
+        _approve(address(templeToken), address(staking), type(uint).max);
+        staking.stake(200 ether);
+
+        t += 2 * WEEK_LENGTH;
+        vm.warp(t);
+        assertEq(staking.getDelegatedVoteWeight(bob), 133333333333333333333);
+        vm.startPrank(mike);
+        _approve(address(templeToken), address(staking), type(uint).max);
+        ITempleGoldStaking.AccountWeightParams memory _weight = staking.getAccountWeights(bob);
+        assertEq(_weight.stakeTime, 0);
+        staking.stake(100 ether);
+        // stake time is 0 after stake
+        _weight = staking.getAccountWeights(bob);
+        assertEq(_weight.stakeTime, 0);
+        // delegate to bob after stake
+        staking.setUserVoteDelegate(bob);
+        // stake time incrases after delegation
+        _weight = staking.getAccountWeights(bob);
+        assertEq(_weight.stakeTime, 483840);
+        assertEq(staking.getDelegatedVoteWeight(bob), 133333333333333333333);
+        staking.unsetUserVoteDelegate();
+        // bob stake time remains the same after reset delegation from mike
+        _weight = staking.getAccountWeights(bob);
+        assertEq(_weight.stakeTime, 483840);
+        // same week
+        assertEq(staking.getDelegatedVoteWeight(bob), 133333333333333333333);
+        t += WEEK_LENGTH;
+        vm.warp(t);
+        _weight = staking.getAccountWeights(bob);
+        assertEq(_weight.stakeTime, 483840);
+        // vote power reduces by 4761904761904761905 (4.7619e18) which is 3.57% of previous vote power
+        // even after withdrawing 100 ether, which is 33% of total delegated votes
+        assertEq(staking.getDelegatedVoteWeight(bob), 128571428571428571428);
+        t += WEEK_LENGTH;
+        vm.warp(t);
+        // increases because it's following week
+        assertEq(staking.getDelegatedVoteWeight(bob), 147368421052631578947);
+        _weight = staking.getAccountWeights(bob);
+        assertEq(_weight.stakeTime, 483840);
+        // delegate and undelegate a couple of time to check if stakeTime reduces
+        staking.setUserVoteDelegate(bob);
+        // stake time for bob increases after delegation
+        _weight = staking.getAccountWeights(bob);
+        assertEq(_weight.stakeTime, 583944);
+        staking.unsetUserVoteDelegate();
+        _weight = staking.getAccountWeights(bob);
+        assertEq(_weight.stakeTime, 583944);
+        assertEq(staking.getDelegatedVoteWeight(bob), 147368421052631578947);
+
+        staking.setUserVoteDelegate(bob);
+        // stake time reduced after delegation
+        _weight = staking.getAccountWeights(bob);
+        assertEq(_weight.stakeTime, 294510);
+        staking.unsetUserVoteDelegate();
+        assertEq(staking.getDelegatedVoteWeight(bob), 147368421052631578947);
+        _weight = staking.getAccountWeights(bob);
+        assertEq(_weight.stakeTime, 294510);
+        t += WEEK_LENGTH;
+        vm.warp(t);
+        assertEq(staking.getDelegatedVoteWeight(bob), 119580349841434469553);
+        _weight = staking.getAccountWeights(bob);
+        assertEq(_weight.stakeTime, 294510);
     }
 
     function test_stake_delegate_vote_weight() public {
@@ -816,33 +1058,37 @@ contract TempleGoldStakingTest is TempleGoldStakingTestBase {
         // alice change delegate and check vote weight of old delegate
         staking.setUserVoteDelegate(executor);
         // vote weight now of delegate is just from mike
-        assertEq(staking.getDelegatedVoteWeight(bob), stakeAmount * 5 / 6);
+        ts += WEEK_LENGTH;
+        vm.warp(ts);
+        assertEq(staking.getDelegatedVoteWeight(bob), stakeAmount * 9 / 10);
+        assertEq(staking.getVoteWeight(mike), stakeAmount * 9 / 10);
 
         // set delegate to false
-        // vm.startPrank(executor);
         vm.startPrank(bob);
         staking.setSelfAsDelegate(false);
-        assertEq(staking.getDelegatedVoteWeight(bob), 0);
-        assertEq(staking.getVoteWeight(alice), stakeAmount * 5 / 6);
+        // same week. using previous week vote weight
+        assertEq(staking.getDelegatedVoteWeight(bob), stakeAmount * 9 / 10);
+        // alice vote weight same increase with increased time
+        assertEq(staking.getVoteWeight(alice), stakeAmount * 9 / 10);
 
         // alice self delegates and vote weight is not double
         vm.startPrank(alice);
         staking.setSelfAsDelegate(true);
         staking.setUserVoteDelegate(alice);
         assertEq(staking.userDelegates(alice), alice);
-        assertEq(staking.getDelegatedVoteWeight(alice), stakeAmount * 5 / 6);
-        assertEq(staking.getVoteWeight(alice), stakeAmount * 5 / 6);
+        // no delegatees 
+        assertEq(staking.getDelegatedVoteWeight(alice), 0);
+        assertEq(staking.getVoteWeight(alice), stakeAmount * 9 / 10);
     }
 
     function test_withdraw_delegate_vote_weight() public {
+        uint64 halfTime = 4 weeks;
+        _setHalftime(halfTime);
+        uint256 ts = block.timestamp / WEEK_LENGTH * WEEK_LENGTH;
         vm.startPrank(bob);
         staking.setSelfAsDelegate(true);
         vm.startPrank(executor);
         staking.setSelfAsDelegate(true);
-        uint256 halfTime = WEEK_LENGTH / 4;
-        staking.setHalfTime(halfTime);
-        // set time to `half_time` before end of a week
-        uint256 ts = (block.timestamp / WEEK_LENGTH + 2) * WEEK_LENGTH - halfTime;
         vm.warp(ts);
 
         vm.startPrank(alice);
@@ -851,7 +1097,8 @@ contract TempleGoldStakingTest is TempleGoldStakingTestBase {
         vm.startPrank(mike);
         staking.setUserVoteDelegate(bob);
         uint256 stakeAmount = 3 ether;
-        // stake
+
+         // stake
         deal(address(templeToken), alice, 100 ether, true);
         deal(address(templeToken), mike, 100 ether, true);
         _approve(address(templeToken), address(staking), type(uint).max);
@@ -860,24 +1107,36 @@ contract TempleGoldStakingTest is TempleGoldStakingTestBase {
         _approve(address(templeToken), address(staking), type(uint).max);
         staking.stake(stakeAmount);
 
-        ts += 2 * halfTime;
+        // warp to halftime
+        ts += WEEK_LENGTH * 4;
         vm.warp(ts);
         assertEq(staking.getVoteWeight(alice), stakeAmount / 2);
-        // delegate weight is 2x (alice + mike)
+        // 2 * stakeAmount is total
         assertEq(staking.getDelegatedVoteWeight(bob), stakeAmount);
 
         // alice withdraws
         staking.withdraw(stakeAmount, true);
-        assertEq(staking.getDelegatedVoteWeight(bob), stakeAmount / 2);
+        // still same week
+        assertEq(staking.getDelegatedVoteWeight(bob), stakeAmount);
+        ts += WEEK_LENGTH;
+        vm.warp(ts);
+        // minus withdraw amount plus 7 days extra vote weights
+        assertEq(staking.getDelegatedVoteWeight(bob), stakeAmount * 5 / 9);
         assertEq(staking.getVoteWeight(alice), 0);
+
         // mike withdraws
         vm.startPrank(mike);
         staking.withdraw(stakeAmount, true);
+        // same week
+        assertEq(staking.getDelegatedVoteWeight(bob), stakeAmount * 5 / 9);
+        assertEq(staking.getVoteWeight(mike), stakeAmount * 5 / 9);
+        ts += WEEK_LENGTH;
+        vm.warp(ts);
         assertEq(staking.getDelegatedVoteWeight(bob), 0);
         assertEq(staking.getVoteWeight(mike), 0);
     }
 
-    function test_unsetUserVoteDelegate() public {
+    function test_unsetUserVoteDelegate_staking() public {
         vm.startPrank(bob);
         staking.setSelfAsDelegate(true);
         vm.startPrank(alice);
@@ -889,6 +1148,7 @@ contract TempleGoldStakingTest is TempleGoldStakingTestBase {
         vm.expectEmit(address(staking));
         emit UserDelegateSet(alice, address(0));
         staking.unsetUserVoteDelegate();
+        assertEq(staking.userDelegates(alice), address(0));
 
         vm.startPrank(executor);
         uint256 halfTime = WEEK_LENGTH / 4;
@@ -910,6 +1170,11 @@ contract TempleGoldStakingTest is TempleGoldStakingTestBase {
         assertEq(staking.getDelegatedVoteWeight(bob), stakeAmount / 2);
 
         staking.unsetUserVoteDelegate();
+        assertEq(staking.userDelegates(alice), address(0));
+        // still same week
+        assertEq(staking.getDelegatedVoteWeight(bob), stakeAmount / 2);
+        ts += WEEK_LENGTH;
+        vm.warp(ts);
         assertEq(staking.getDelegatedVoteWeight(bob), 0);
     }
 }


### PR DESCRIPTION
## Description
In TempleGoldStaking contract, when a delegate resets self delegation, the vote weights delegated to the delegate will be removed by calling _updateAccountWeight.
Since zero is passed as new balance parameter, the stakingTime of vote weight is reset to zero:
```solidity
// TempleGoldStaking.sol:L580
if (_newBalance == 0) {
    t = 0;
    _lastShares = 0;
}
```
This means that the delegate's vote weight starts accumulating from zero even though the delegate has their own balance, which should not be decreased.

## Impact
It has Medium severity because the delegate loses voting power, even becoming zero if resetting self delegation happens right before an epoch ends.

## Recommendation
When resetting self delegation, it should not decrease stakeTime so that delegate's voting power remains based on their own balance



# Checklist
- [ ] Code follows the style guide
- [ ] I have performed a self-review of my own code
- [ ] New and existing tests pass locally
- [ ] This PR is targeting the correct branch 