### PR TITLE
hawks l01

### DIFF
--- a/protocol/contracts/templegold/TempleTeleporter.sol
+++ b/protocol/contracts/templegold/TempleTeleporter.sol
@@ -90,7 +90,7 @@ contract TempleTeleporter is ITempleTeleporter, OApp {
         uint256 _amount,
         bytes memory _options
     ) external view returns (MessagingFee memory fee) {
-        return _quote(_dstEid, abi.encodePacked(_to, _amount), _options, false);
+        return _quote(_dstEid, abi.encodePacked(_to.addressToBytes32(), _amount), _options, false);
     }
 
     /// @dev Called when data is received from the protocol. It overrides the equivalent function in the parent contract.


### PR DESCRIPTION
## Summary

`TempleTeleporter.quote()` will return a fee value lower than will be required for sending a message via `TempleTeleporter.teleport()`. This is because the way both functions construct the layerzero message/payload is different. `TempleTeleporter.quote()` uses `abi.encodePacked(_to, _amount)` while `TempleTeleporter.teleport()` uses `abi.encodePacked(to.addressToBytes32(), amount)`.

`TempleTeleporter.quote()` is a function used for getting the fee amount needed for sending a layerZero message via `TempleTeleporter.teleport()`. `TempleTeleporter.quote()` does not calculate properly/underestimates the fee amount because of this difference mentioned above.

## Vulnerability Details

The conversion of the recipient address `to` into bytes, as implemented in [[TempleTeleporter.teleport()](https://github.com/Cyfrin/2024-07-templegold/blob/57a3e597e9199f9e9e0c26aab2123332eb19cc28/protocol/contracts/templegold/TempleTeleporter.sol#L52)](https://github.com/Cyfrin/2024-07-templegold/blob/57a3e597e9199f9e9e0c26aab2123332eb19cc28/protocol/contracts/templegold/TempleTeleporter.sol#L52), results in a higher messaging fee for a sucessfull teleport() call. This occurs because the message or payload generated in `TempleTeleporter.teleport()` is longer due to the address conversion to bytes before encoding. In contrast, TempleTeleporter.quote() does not convert the address to bytes before encoding, resulting in a shorter message and thus a lower message fee is calculated. Because of thie `quote()` will always return an underestimated value required for a sucessfull `teleport()` call.

## Impact 

`TempleTeleporter.quote()`does not return the correct fee amount require for a layerZero message via `TempleTeleporter.teleport()`

## Recommendations

ensure consistency between both functions, use same methods for generating the layerzero payload/message in both functions.


# Checklist
- [ ] Code follows the style guide
- [ ] I have performed a self-review of my own code
- [ ] New and existing tests pass locally
- [ ] This PR is targeting the correct branch 