### PR TITLE
Hawks l02

### DIFF
--- a/protocol/contracts/templegold/TempleGoldStaking.sol
+++ b/protocol/contracts/templegold/TempleGoldStaking.sol
@@ -183,7 +183,7 @@ contract TempleGoldStaking is ITempleGoldStaking, TempleElevatedAccess, Pausable
      * @notice Distributed TGLD rewards minted to this contract to stakers
      * @dev This starts another epoch of rewards distribution. Calculates new `rewardRate` from any left over rewards up until now
      */
-    function distributeRewards() external updateReward(address(0), 0) {
+    function distributeRewards() external whenNotPaused updateReward(address(0), 0) {
         if (distributionStarter != address(0) && msg.sender != distributionStarter) 
             { revert CommonEventsAndErrors.InvalidAccess(); }
         if (totalSupply == 0) { revert NoStaker(); }
@@ -279,7 +279,7 @@ contract TempleGoldStaking is ITempleGoldStaking, TempleElevatedAccess, Pausable
      * @notice Withdraw staked tokens
      * @param index Index of stake
      */
-    function withdraw(uint256 index) external override {
+    function withdraw(uint256 index) external override whenNotPaused {
         StakeInfo storage _stakeInfo = _stakeInfos[msg.sender][index];
         _withdrawFor(_stakeInfo, msg.sender, msg.sender, index, _stakeInfo.amount, true, msg.sender);
     }
@@ -391,14 +391,14 @@ contract TempleGoldStaking is ITempleGoldStaking, TempleElevatedAccess, Pausable
     function getReward(
         address staker,
         uint256 index
-    ) external override updateReward(staker, index) {
+    ) external override whenNotPaused updateReward(staker, index) {
         _getReward(staker, staker, index);
     }
 
     /**  
      * @notice Mint and distribute Temple Gold rewards 
      */
-    function distributeGold() external {
+    function distributeGold() external whenNotPaused {
         _distributeGold();
     }
 


### PR DESCRIPTION
## Summary

The `TempleGoldStaking.sol` contract features a `whenNotPaused` modifier that is currently only applied to the `stakeFor()` function. This limited application of the pausing functionality could leave critical operations exposed during emergencies, potentially jeopardizing the safety of staked assets and reward distributions.

## Vulnerability Details
`withdraw()` and `withdrawAll()` functions that allow users to withdraw staked tokens and claim rewards are not protected by the pausing mechanism.

`getReward()`function facilitates the claiming of rewards and is not covered by the pausing control.

`distributeRewards()`and`distributeGold()` reward distribution functions are also not pausable.

## Impact

The lack of comprehensive pause functionality exposes the contract to potential issues if the contract needs to be paused for maintenance or in response to an attack. By not restricting all non-migration functions during a pause, users can still interact with the contract in ways that may not be intended during a paused state, i.e. if an emergency occurs (e.g., a security vulnerability is discovered), the contract cannot be fully paused to protect funds and prevent unauthorized transactions. This could lead to:

Unauthorized withdrawals and claims of rewards during a security breach.

Potential loss of staked tokens and rewards if a vulnerability is exploited before a fix can be applied.

Increased risk to user assets, as pausing is a common safeguard to mitigate damage during incidents.

## Tools Used

Manual review.

## Recommendations

Apply `whenNotPaused` modifier to mentioned critical functions.



Fixes # (issue)

# Checklist
- [ ] Code follows the style guide
- [ ] I have performed a self-review of my own code
- [ ] New and existing tests pass locally
- [ ] This PR is targeting the correct branch 