### PR TITLE
hawks l03

### DIFF
--- a/protocol/contracts/templegold/SpiceAuction.sol
+++ b/protocol/contracts/templegold/SpiceAuction.sol
@@ -314,9 +314,10 @@ contract SpiceAuction is ISpiceAuction, AuctionBase {
         uint256 epochId = _currentEpochId;
         EpochInfo storage info = epochs[epochId];
         /// @dev use `removeAuctionConfig` for case where `auctionStart` is called and cooldown is still pending
-        if (info.startTime == 0) { revert InvalidConfigOperation(); }
-        if (!info.hasEnded() && auctionConfigs[epochId+1].duration == 0) { revert RemoveAuctionConfig(); }
-        
+        if (epochId != 0) {
+            if (info.startTime == 0) { revert InvalidConfigOperation(); }
+            if (!info.hasEnded() && auctionConfigs[epochId+1].duration == 0) { revert RemoveAuctionConfig(); }
+        }
 
         /// @dev Now `auctionStart` is not triggered but `auctionConfig` is set (where _currentEpochId is not updated yet)
     

--- a/protocol/test/forge/templegold/SpiceAuction.t.sol
+++ b/protocol/test/forge/templegold/SpiceAuction.t.sol
@@ -364,8 +364,17 @@ contract SpiceAuctionTest is SpiceAuctionTestBase {
         address _templeGold = address(templeGold);
         uint256 recoverAmount = 1 ether;
         // _currentEpochId = 0
-        vm.expectRevert(abi.encodeWithSelector(ISpiceAuction.InvalidConfigOperation.selector));
-        spice.recoverToken(_spiceToken, alice, recoverAmount);
+        // recover bid token, wrong amount
+        vm.expectRevert(abi.encodeWithSelector(CommonEventsAndErrors.InvalidParam.selector));
+        spice.recoverToken(_spiceToken, alice, recoverAmount+1);
+        
+        uint256 daoDaiBalanceBefore = IERC20(daiToken).balanceOf(daoExecutor);
+        deal(address(daiToken), address(spice), recoverAmount, true);
+        vm.expectEmit(address(spice));
+        emit TokenRecovered(daoExecutor, daiToken, recoverAmount);
+        vm.startPrank(daoExecutor);
+        spice.recoverToken(_spiceToken, address(daoExecutor), recoverAmount);
+        assertEq(recoverAmount+daoDaiBalanceBefore, IERC20(daiToken).balanceOf(daoExecutor));
 
         _startAuction(true, true);
         IAuctionBase.EpochInfo memory info = spice.getEpochInfo(1);


### PR DESCRIPTION
## Summary

The `SpiceAuction::recoverToken()` function is used to recover the auction tokens (either temple gold or a spice token) for an auction whose config is set, but hasn't started yet. However, for auction id 1 (and epoch id 0, since auction hasn't started yet), tokens can never be recovered if the dao wanted to do so.

> **NOTE**
> Auction id isn't a state variable. It is used to better represent the latest auction number. Auction config is set for the `_currentEpochId` + 1 index, and the `_currentEpochId` variable lags behind the auction id by 1 until the auction starts. Then the `_currentEpochId` is incremented, and epoch info is set.

For the first spice auction which hasn't started yet (auction id 1 and epoch id 0), the epoch info hasn't been set (it is set once the `SpiceAuction::startAuction()` function is called). Thus, [[L#249](https://github.com/Cyfrin/2024-07-templegold/blob/57a3e597e9199f9e9e0c26aab2123332eb19cc28/protocol/contracts/templegold/SpiceAuction.sol#L249)](https://github.com/Cyfrin/2024-07-templegold/blob/57a3e597e9199f9e9e0c26aab2123332eb19cc28/protocol/contracts/templegold/SpiceAuction.sol#L249) accesses a non-existent epoch info (all fields in the struct hold value 0) and the function reverts at [[L#251](https://github.com/Cyfrin/2024-07-templegold/blob/57a3e597e9199f9e9e0c26aab2123332eb19cc28/protocol/contracts/templegold/SpiceAuction.sol#L251)](https://github.com/Cyfrin/2024-07-templegold/blob/57a3e597e9199f9e9e0c26aab2123332eb19cc28/protocol/contracts/templegold/SpiceAuction.sol#L251).

Additionally, auction tokens cannot be recovered during the cooldown period. This will revert at [[L#252](https://github.com/Cyfrin/2024-07-templegold/blob/57a3e597e9199f9e9e0c26aab2123332eb19cc28/protocol/contracts/templegold/SpiceAuction.sol#L252)](https://github.com/Cyfrin/2024-07-templegold/blob/57a3e597e9199f9e9e0c26aab2123332eb19cc28/protocol/contracts/templegold/SpiceAuction.sol#L252).

## Impact

The dao executor won't be able to recover tokens for the first ever spice auction. This is essentially a DOS type of vulnerability.
# Checklist
- [ ] Code follows the style guide
- [ ] I have performed a self-review of my own code
- [ ] New and existing tests pass locally
- [ ] This PR is targeting the correct branch 