### PR TITLE
hawks l04

### DIFF
--- a/protocol/contracts/interfaces/templegold/IDaiGoldAuction.sol
+++ b/protocol/contracts/interfaces/templegold/IDaiGoldAuction.sol
@@ -38,6 +38,13 @@ interface IDaiGoldAuction is IAuctionBase {
     function nextAuctionGoldAmount() external view returns (uint256);
 
     /**
+     * @notice Recover auction tokens for epoch with zero bids
+     * @param epochId Epoch Id
+     * @param to Recipient
+     */
+    function recoverTempleGoldForZeroBidAuction(uint256 epochId, address to) external;
+
+    /**
      * @notice Get auction configuration
      * @return Auction configuration
      */

--- a/protocol/contracts/templegold/DaiGoldAuction.sol
+++ b/protocol/contracts/templegold/DaiGoldAuction.sol
@@ -300,6 +300,26 @@ contract DaiGoldAuction is IDaiGoldAuction, AuctionBase, TempleElevatedAccess {
     }
 
     /**
+     * @notice Recover auction tokens for epoch with zero bids
+     * @param epochId Epoch Id
+     * @param to Recipient
+     */
+    function recoverTempleGoldForZeroBidAuction(uint256 epochId, address to) external override onlyElevatedAccess {
+        if (to == address(0)) { revert CommonEventsAndErrors.InvalidAddress(); }
+        // has to be valid epoch
+        if (epochId > _currentEpochId) { revert InvalidEpoch(); }
+        // epoch has to be ended
+        EpochInfo storage epochInfo = epochs[epochId];
+        if (!epochInfo.hasEnded()) { revert AuctionActive(); }
+        // bid token amount for epoch has to be 0
+        if (epochInfo.totalBidTokenAmount > 0) { revert InvalidOperation(); }
+
+        uint256 amount = epochInfo.totalAuctionTokenAmount;
+        emit CommonEventsAndErrors.TokenRecovered(to, address(templeGold), amount);
+        templeGold.safeTransfer(to, amount);
+    }
+
+    /**
      * @notice Mint and distribute TGOLD 
      */
     function distributeGold() external {


### PR DESCRIPTION
## Summary

When an auction ends with 0 bids, the `totalAuctionTokenAmount` value of TGLD tokens remain locked forever as `DaiGoldAuction::recoverToken()` function can only be used when the auction is still in its cooldown period.

## Vulnerability Details

`DaiGoldAuction::recoverToken` provides a mechanism to recover tokens that have been distributed and allotted to a specific auction only **BEFORE** the auction starts, that is during the cooldown period as evident by the code below,

When users bid in an auction, they are entitled to their claims, even if there's just one bid, that bidder deserves the entire pot. Users are also allowed to claim tokens from a previous auction as they please, hence we need not worry about tokens remaining stuck in the contract.

However this is not the case when an auction ends with no bids, as in such a situation we would want to recover those tokens as there are no claims. This is prevented by the fact that tokens cannot be recovered after an auction ends.

## Impact

`totalAuctionTokenAmount` value worth of tokens allotted for the auction would remain permanently stuck inside the contract. If this scenario repeats multiple times, a significant amount of tokens would be cut out from circulation.


# Checklist
- [ ] Code follows the style guide
- [ ] I have performed a self-review of my own code
- [ ] New and existing tests pass locally
- [ ] This PR is targeting the correct branch 