### PR TITLE
hawks l05

### DIFF
--- a/protocol/contracts/templegold/TempleGoldStaking.sol
+++ b/protocol/contracts/templegold/TempleGoldStaking.sol
@@ -184,8 +184,7 @@ contract TempleGoldStaking is ITempleGoldStaking, TempleElevatedAccess, Pausable
      * @dev This starts another epoch of rewards distribution. Calculates new `rewardRate` from any left over rewards up until now
      */
     function distributeRewards() external whenNotPaused updateReward(address(0), 0) {
-        if (distributionStarter != address(0) && msg.sender != distributionStarter) 
-            { revert CommonEventsAndErrors.InvalidAccess(); }
+        if (msg.sender != distributionStarter) { revert CommonEventsAndErrors.InvalidAccess(); }
         if (totalSupply == 0) { revert NoStaker(); }
         // Mint and distribute TGLD if no cooldown set
         if (lastRewardNotificationTimestamp + rewardDistributionCoolDown > block.timestamp) 


### PR DESCRIPTION
## Summary

Calling `TempleGoldStaking::distributeRewards()` upadates the `rewwardData.periodFinish` paramater which specificies when reward distribution is supposed to stop however when a starter is not set, a malicious user can call this function towards the end of a reward duration which will renew the `rewardData.periodFinish` paramater making the reward period go beyond the intended time.

## Vulnarebility Details

In the `TempleGoldStaking` contract it is possible for rewardDistribution to be started by anyone when a starter is not set.
The `rewardData.periodFinish` paramater is renewed when the above function is called making the reward period go beyond the intended time.

## POC

* We have user A and B
  User A is the reward distribution starter but has not been set in the contract.

* User A starts the Reward Distribution for a duration that has been set.

* Towards the end of this reward distribution duration, User B maliciously calls `TempleGoldStaking::distributeRewards()` just to prevent the reward distribution from stopping.

* This would go against user A's intentions as he may have wanted to add a reward duration and vesting period to be added. Which is now impossible due to the renewed `rewardData.periodfinish`. Even more gold will be distributrd than intended for this specific reward duration.

## Impact

This makes the reward distribution to go beyond the intended time and makes it impossible to set a new reward duration and vesting period.

\##Tools
Manual Review

## Recommendation

Make it impossible for anyone to start Rewards distribution by ensuring only a single starter is supposed to do so. 


# Checklist
- [ ] Code follows the style guide
- [ ] I have performed a self-review of my own code
- [ ] New and existing tests pass locally
- [ ] This PR is targeting the correct branch 