### PR TITLE
hawks m01

### DIFF
--- a/protocol/contracts/templegold/SpiceAuction.sol
+++ b/protocol/contracts/templegold/SpiceAuction.sol
@@ -161,6 +161,9 @@ contract SpiceAuction is ISpiceAuction, AuctionBase {
         if (!configSetButAuctionStartNotCalled) {
             /// @dev unlikely because this is a DAO execution, but avoid deleting old ended auctions
             if (info.hasEnded()) { revert AuctionEnded(); }
+            SpiceAuctionConfig storage config = auctionConfigs[id];
+            (,address auctionToken) = _getBidAndAuctionTokens(config);
+            _totalAuctionTokenAllocation[auctionToken] -= info.totalAuctionTokenAmount;
             /// auction was started but cooldown has not passed yet
             delete auctionConfigs[id];
             delete epochs[id];


### PR DESCRIPTION
## Vulnerability Details

[removeAuctionConfig](https://github.com/Cyfrin/2024-07-templegold/blob/57a3e597e9199f9e9e0c26aab2123332eb19cc28/protocol/contracts/templegold/SpiceAuction.sol#L107-L133) is used to remove auction config set for last epoch. If the auction was started but the cooldown has not passed yet, both auction config and epoch info are deleted and the `_currentEpochId` is decremented:

The issue is that `_totalAuctionTokenAllocation` is not updated in this situation and this will lead to the following consequences for the next epochs:

1. `_totalAuctionTokenAllocation` will always contain extra auction tokens for all subsequent epochs.
2. Those extra auction tokens can not be recovered.

## Impact

If the last auction config at cooldown is removed, two serious impacts will occur:

1. `_totalAuctionTokenAllocation` will always contain extra auction tokens for all subsequent epochs.
2. Those extra auction tokens can not be recovered.

## Tools Used

Manual Review

## Recommendations

Consider updating `_totalAuctionTokenAllocation` when removing the config of the last started auction at the cooldown period. Below is a suggestion for an updated code of `SpiceAuction::removeAuctionConfig`:


# Checklist
- [ ] Code follows the style guide
- [ ] I have performed a self-review of my own code
- [ ] New and existing tests pass locally
- [ ] This PR is targeting the correct branch 