### PR TITLE
Round TPI to 2 decimal places on borrow page

### DIFF
--- a/apps/dapp/src/components/Pages/Core/DappPages/Borrow/index.tsx
+++ b/apps/dapp/src/components/Pages/Core/DappPages/Borrow/index.tsx
@@ -102,7 +102,7 @@ export const BorrowPage = () => {
       templePrice: data.tokens.filter((t: any) => t.symbol == 'TEMPLE')[0]
         .price,
       daiPrice: data.tokens.filter((t: any) => t.symbol == 'DAI')[0].price,
-      tpi: data.treasuryReservesVaults[0].treasuryPriceIndex,
+      tpi: Number(data.treasuryReservesVaults[0].treasuryPriceIndex),
     });
   }, []);
 
@@ -718,7 +718,9 @@ export const BorrowPage = () => {
               <BrandParagraph>Current Borrow APY </BrandParagraph>
             </MetricContainer>
             <MetricContainer>
-              <LeadMetric>{showLoading ? '...' : prices.tpi}</LeadMetric>
+              <LeadMetric>
+                {showLoading ? '...' : prices.tpi.toFixed(2)}
+              </LeadMetric>
               <BrandParagraph>Current TPI</BrandParagraph>
             </MetricContainer>
           </Metrics>


### PR DESCRIPTION
# Description

With new TPI calculations, we need to round the TPI to 2 decimal places for display in the dapp.
<img width="123" alt="Screenshot 2024-10-31 at 10 35 48 AM" src="https://github.com/user-attachments/assets/d493ee74-f6f9-4413-a548-1b58d46a34c4">



# Checklist
- [ ] Code follows the style guide
- [ ] I have performed a self-review of my own code
- [ ] New and existing tests pass locally
- [ ] This PR is targeting the correct branch 