### PR TITLE
Update gh actions to use github_token

### DIFF
--- a/.github/workflows/dapp-prod.yaml
+++ b/.github/workflows/dapp-prod.yaml
@@ -19,7 +19,7 @@ jobs:
           vercel-args: '--prod -A apps/dapp/vercel.json' #Optional
           vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}  #Required
           vercel-project-id: ${{ secrets.DAPP_PROJECT_ID }} #Required
-          github-token: ${{ secrets.CI_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           github-comment: false
           scope: ${{ secrets.VERCEL_ORG_ID }}
           alias-domains: | #Optional

--- a/.github/workflows/dapp-stage.yaml
+++ b/.github/workflows/dapp-stage.yaml
@@ -18,7 +18,7 @@ jobs:
           vercel-args: '-A apps/dapp/vercel.json' #Optional
           vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}  #Required
           vercel-project-id: ${{ secrets.DAPP_PROJECT_ID }} #Required
-          github-token: ${{ secrets.CI_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           github-comment: false
           scope: ${{ secrets.VERCEL_ORG_ID }}
           alias-domains: | #Optional

--- a/.github/workflows/vercel-preview.yaml
+++ b/.github/workflows/vercel-preview.yaml
@@ -7,6 +7,9 @@ jobs:
   vercel-deploy:
     if: contains(github.event.pull_request.labels.*.name, 'preview-deploy')
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - name: checkout code
         uses: actions/checkout@v4
@@ -15,7 +18,7 @@ jobs:
         uses: amondnet/vercel-action@v25
         with:
           vercel-token: ${{ secrets.VERCEL_TOKEN }}
-          github-token: ${{ secrets.CI_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           vercel-args: '-A apps/dapp/vercel.json'
           vercel-org-id: ${{ secrets.VERCEL_ORG_ID}}
           scope: ${{ secrets.VERCEL_ORG_ID }}


### PR DESCRIPTION
# Description

While fixing https://github.com/TempleDAO/shrine/pull/358 discovered we don't need our own PAT in CI_TOKEN we can use GITHUB_TOKEN which is available "for free" in actions. This makes the same change in this repo.

# Checklist
- [ ] Code follows the style guide
- [ ] I have performed a self-review of my own code
- [ ] New and existing tests pass locally
- [ ] This PR is targeting the correct branch 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated authentication and permission settings across production, staging, and preview deployment workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->