### PR TITLE
Prompt to connect in TOS modal

### DIFF
--- a/apps/dapp/src/components/Pages/Core/DappPages/SpiceBazaar/components/Popover.tsx
+++ b/apps/dapp/src/components/Pages/Core/DappPages/SpiceBazaar/components/Popover.tsx
@@ -1,4 +1,4 @@
-import { useRef, FC, ReactNode, useEffect } from 'react';
+import { useRef, FC, ReactNode, useEffect, useCallback } from 'react';
 import styled from 'styled-components';
 import { backgroundImage, buttonResets } from 'styles/mixins';
 import { useOutsideClick } from 'hooks/use-outside-click';
@@ -25,10 +25,12 @@ export const Popover: FC<Props> = ({
 }) => {
   const ref = useRef<HTMLDivElement>(null);
 
-  useOutsideClick(ref, () => {
+  const handleOutsideClick = useCallback(() => {
     if (!closeOnClickOutside) return;
     onClose();
-  });
+  }, [closeOnClickOutside, onClose]);
+
+  useOutsideClick(ref, handleOutsideClick);
 
   // Close modal on escape
   useEffect(() => {

--- a/apps/dapp/src/components/Pages/Core/DappPages/SpiceBazaar/components/SpiceBazaarTOS.tsx
+++ b/apps/dapp/src/components/Pages/Core/DappPages/SpiceBazaar/components/SpiceBazaarTOS.tsx
@@ -4,6 +4,7 @@ import { useState, useRef, useEffect } from 'react';
 import styled from 'styled-components';
 import { Button } from 'components/Button/Button';
 import { useWallet } from 'providers/WalletProvider';
+import { useConnectWallet } from '@web3-onboard/react';
 import * as breakpoints from 'styles/breakpoints';
 import { backgroundImage, buttonResets } from 'styles/mixins';
 import close from 'assets/icons/close.svg';
@@ -19,15 +20,19 @@ interface SpiceBazaarTOSProps {
   onCancel: () => void;
 }
 
+const WALLET_CONNECTION_ERROR = 'Connect a wallet to sign the Terms.';
+
 export const SpiceBazaarTOS = ({
   onSuccess,
   onCancel,
 }: SpiceBazaarTOSProps) => {
   const { signer, wallet: walletAddress, getConnectedSigner } = useWallet();
+  const [{}, connect] = useConnectWallet();
   const [hasScrolledToBottom, setHasScrolledToBottom] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
+  const isWalletConnected = !!walletAddress;
 
   const handleScroll = () => {
     const container = scrollContainerRef.current;
@@ -55,7 +60,7 @@ export const SpiceBazaarTOS = ({
 
   const handleSign = async () => {
     if (!walletAddress) {
-      setError('Connect a wallet to sign the Terms.');
+      setError(WALLET_CONNECTION_ERROR);
       return;
     }
 
@@ -105,13 +110,14 @@ export const SpiceBazaarTOS = ({
       window.localStorage[getSpiceBazaarTosStorageKey(normalizedWallet)] =
         tosData;
       onSuccess();
-    } catch (err: any) {
+    } catch (err: unknown) {
       console.error('TOS signature failed:', err);
+      const typedError = err as { code?: number | string; message?: string };
       // Show error message instead of closing the modal
       const errorMessage =
-        err?.code === 'ACTION_REJECTED' || err?.code === 4001
+        typedError?.code === 'ACTION_REJECTED' || typedError?.code === 4001
           ? 'Signature rejected. Please try again.'
-          : err?.message || 'Signature failed. Please try again.';
+          : typedError?.message || 'Signature failed. Please try again.';
       setError(errorMessage);
     } finally {
       setIsLoading(false);
@@ -168,12 +174,22 @@ export const SpiceBazaarTOS = ({
         </ErrorMessage>
       )}
 
-      <SignButton
-        onClick={handleSign}
-        disabled={!hasScrolledToBottom || isLoading}
-      >
-        {isLoading ? 'SIGNING...' : 'I AGREE'}
-      </SignButton>
+      {isWalletConnected ? (
+        <SignButton
+          onClick={handleSign}
+          disabled={!hasScrolledToBottom || isLoading}
+        >
+          {isLoading ? 'SIGNING...' : 'I AGREE'}
+        </SignButton>
+      ) : (
+        <SignButton
+          onClick={() => {
+            connect();
+          }}
+        >
+          CONNECT WALLET
+        </SignButton>
+      )}
     </Container>
   );
 };
@@ -317,11 +333,6 @@ const ErrorMessage = styled.div`
   border: 1px solid rgba(220, 38, 38, 0.3);
   border-radius: 8px;
   width: 100%;
-`;
-
-const ErrorIcon = styled.span`
-  font-size: 18px;
-  line-height: 1;
 `;
 
 const ErrorText = styled.p`

--- a/apps/dapp/src/hooks/use-outside-click.tsx
+++ b/apps/dapp/src/hooks/use-outside-click.tsx
@@ -16,5 +16,5 @@ export function useOutsideClick(
     return () => {
       document.removeEventListener('mousedown', handleClickOutside);
     };
-  }, [ref]);
+  }, [ref, handler]);
 }


### PR DESCRIPTION
# Description

Now when you see the TOS, and your wallet is not connected, you see a "Connect Wallet" button right in the modal, and once you connect, you'll see the "I Agree" as before.



<img width="594" height="399" alt="connect wallet" src="https://github.com/user-attachments/assets/9428dbbb-605a-4e0e-a4d9-40e6ed6e67e1" />

<img width="614" height="405" alt="I agree" src="https://github.com/user-attachments/assets/a084c895-c6e2-4775-a739-b048e161f352" />


# Checklist
- [ ] Code follows the style guide
- [ ] I have performed a self-review of my own code
- [ ] New and existing tests pass locally
- [ ] This PR is targeting the correct branch 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Terms of Service page shows a single dynamic action button: "Connect Wallet" when disconnected and "I AGREE" when connected.
  * Wallet connection status gates the agree/sign action to prevent unintended actions.

* **Bug Fixes**
  * Clearer wallet connection error messaging and more robust error handling during signing.
  * Outside-click handling updated so popovers respond correctly when the click handler changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->