### PR TITLE
Scrolling charts in TGLD auctions

### DIFF
--- a/apps/dapp/src/components/Pages/Core/DappPages/SpiceBazaar/Bid/Chart/TgldAuctionChart.tsx
+++ b/apps/dapp/src/components/Pages/Core/DappPages/SpiceBazaar/Bid/Chart/TgldAuctionChart.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import styled from 'styled-components';
 import { BarChart as CustomBarChart, DotChart } from '../../components/Charts';
 import Loader from 'components/Loader/Loader';
@@ -11,7 +11,6 @@ import {
   InputSelect as SingleInputSelect,
   type Option as SingleOption,
 } from 'components/InputSelect/InputSelect';
-import * as breakpoints from 'styles/breakpoints';
 import {
   useStableGoldAuctionMetrics,
   MetricType,
@@ -84,19 +83,24 @@ export const TgldAuctionChart = () => {
 
   // --- Multi-select auctions (for bar charts) ---
   const auctionOptions: Option[] = useMemo(() => {
-    return [...new Set((metrics ?? []).map((m) => m.date))].map((date) => ({
-      label: date,
-      value: date.toLowerCase().replace(/\s/g, '-'),
-    }));
+    return (metrics ?? [])
+      .slice()
+      .reverse()
+      .map((m) => ({
+        label: `${m.date} ${new Date(m.timestamp * 1000).getFullYear()}`,
+        value: m.timestamp.toString(),
+      }));
   }, [metrics]);
 
   const [selectedAuctions, setSelectedAuctions] = useState<Option[]>([]);
+  const initialized = useRef(false);
 
   useEffect(() => {
-    if (auctionOptions.length && selectedAuctions.length === 0) {
+    if (!initialized.current && auctionOptions.length) {
       setSelectedAuctions(auctionOptions);
+      initialized.current = true;
     }
-  }, [auctionOptions, selectedAuctions.length]);
+  }, [auctionOptions]);
 
   const handleAuctionChange = (selected: Option[]) => {
     setSelectedAuctions(selected);
@@ -116,7 +120,11 @@ export const TgldAuctionChart = () => {
     // isBidHistory guard above ensures selectedMetric is a valid MetricType key
     const metricKey = selectedMetric as MetricType;
     return metrics
-      .filter((d) => selectedAuctions.some((option) => option.label === d.date))
+      .filter((d) =>
+        selectedAuctions.some(
+          (option) => option.value === d.timestamp.toString()
+        )
+      )
       .sort((a, b) => a.timestamp - b.timestamp)
       .map((d) => ({
         ...d,
@@ -203,38 +211,48 @@ export const TgldAuctionChart = () => {
   return (
     <PageContainer>
       <HeaderContainer>
-        <SingleInputSelect
-          options={metricOptions}
-          defaultValue={metricOptions.find(
-            (option) => option.value === selectedMetric
-          )}
-          onChange={handleMetricChange}
-          width="280px"
-          fontSize="1rem"
-          maxMenuItems={7}
-          isSearchable={false}
-        />
-
-        {isBidHistory ? (
+        <SelectWrapper>
           <SingleInputSelect
-            options={epochOptions}
-            value={selectedEpoch}
-            onChange={handleEpochChange}
-            width="280px"
+            options={metricOptions}
+            defaultValue={metricOptions.find(
+              (option) => option.value === selectedMetric
+            )}
+            onChange={handleMetricChange}
             fontSize="1rem"
+            textAlign="left"
+            fontWeight="normal"
             maxMenuItems={7}
             isSearchable={false}
           />
+        </SelectWrapper>
+
+        {isBidHistory ? (
+          <SelectWrapper>
+            <SingleInputSelect
+              options={epochOptions}
+              value={selectedEpoch}
+              onChange={handleEpochChange}
+              width="280px"
+              fontSize="1rem"
+              maxMenuItems={7}
+              isSearchable={false}
+            />
+          </SelectWrapper>
         ) : (
-          <MultiInputSelect
-            options={auctionOptions}
-            value={selectedAuctions}
-            onChange={handleAuctionChange}
-            width="200px"
-            fontSize="1rem"
-            maxMenuItems={7}
-            textAlloptions="All Epochs"
-          />
+          <SelectWrapper>
+            <MultiInputSelect
+              options={auctionOptions}
+              value={selectedAuctions}
+              onChange={handleAuctionChange}
+              fontSize="1rem"
+              textAlign="left"
+              fontWeight="normal"
+              maxMenuItems={7}
+              textAlloptions="All Epochs"
+              onSelectAll={() => setSelectedAuctions(auctionOptions)}
+              onSelectNone={() => setSelectedAuctions([])}
+            />
+          </SelectWrapper>
         )}
       </HeaderContainer>
 
@@ -285,13 +303,28 @@ export const TgldAuctionChart = () => {
       ) : (
         <CustomBarChart
           chartData={barChartData}
-          xDataKey="date"
+          xDataKey="timestamp"
           yDataKey="value"
-          xTickFormatter={(val: any) => val}
+          xTickFormatter={(val: number) =>
+            new Date(val * 1000).toLocaleDateString('en-GB', {
+              month: 'short',
+              day: 'numeric',
+            })
+          }
           yTickFormatter={chartConfig.yTickFormatter}
-          tooltipLabelFormatter={(value: string) => {
-            const found = barChartData.find((d) => d.date === value);
-            return found?.id ? `Auction ID: ${found.id}` : value;
+          tooltipLabelFormatter={(value: number) => {
+            const found = barChartData.find((d) => d.timestamp === value);
+            const year = found
+              ? new Date(found.timestamp * 1000).getFullYear()
+              : '';
+            return (
+              <>
+                {found?.id && <div>Auction ID: {found.id}</div>}
+                <div>
+                  End Date: {found?.date} {year}
+                </div>
+              </>
+            );
           }}
           tooltipValuesFormatter={chartConfig.tooltipValuesFormatter}
           xAxisTitle="Auction end date"
@@ -305,6 +338,7 @@ export const TgldAuctionChart = () => {
 };
 
 const PageContainer = styled.div`
+  width: 100%;
   height: 100%;
   display: flex;
   flex-direction: column;
@@ -313,14 +347,14 @@ const PageContainer = styled.div`
 
 const HeaderContainer = styled.div`
   display: flex;
-  flex-direction: column;
-  gap: 15px;
+  flex-wrap: wrap;
+  width: 100%;
+  gap: 15px 40px;
+  align-items: center;
+`;
 
-  ${breakpoints.phoneAndAbove(`
-    flex-direction: row;
-    gap: 40px;
-    align-items: center;
-  `)}
+const SelectWrapper = styled.div`
+  width: 200px;
 `;
 
 const NoDataContainer = styled.div`

--- a/apps/dapp/src/components/Pages/Core/DappPages/SpiceBazaar/components/Charts/BarChart.tsx
+++ b/apps/dapp/src/components/Pages/Core/DappPages/SpiceBazaar/components/Charts/BarChart.tsx
@@ -49,6 +49,7 @@ export default function CustomBarChart<T>({
   const theme = useTheme();
   const isPhoneOrAbove = useMediaQuery({ query: queryPhone });
   const [activeIndex, setActiveIndex] = useState<number | null>(null);
+  const [isTouchActive, setIsTouchActive] = useState(false);
 
   const yAxisNumberFormatter = useMemo(
     () => new Intl.NumberFormat('en-US', { maximumSignificantDigits: 6 }),
@@ -275,7 +276,10 @@ export default function CustomBarChart<T>({
                   <Tooltip
                     wrapperStyle={{
                       outline: 'none',
-                      visibility: activeIndex === null ? 'hidden' : 'visible',
+                      visibility:
+                        activeIndex === null && !isTouchActive
+                          ? 'hidden'
+                          : 'visible',
                     }}
                     cursor={false}
                     contentStyle={{
@@ -319,6 +323,8 @@ export default function CustomBarChart<T>({
                     barSize={minBarWidth}
                     onMouseEnter={(_, index) => setActiveIndex(index)}
                     onMouseLeave={() => setActiveIndex(null)}
+                    onTouchStart={() => setIsTouchActive(true)}
+                    onTouchEnd={() => setIsTouchActive(false)}
                   >
                     {chartData.map((entry: T, index) => {
                       const key =

--- a/apps/dapp/src/components/Pages/Core/DappPages/SpiceBazaar/components/Charts/BarChart.tsx
+++ b/apps/dapp/src/components/Pages/Core/DappPages/SpiceBazaar/components/Charts/BarChart.tsx
@@ -1,4 +1,10 @@
-import React, { useCallback, useMemo, useState } from 'react';
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import {
   ResponsiveContainer,
   BarChart,
@@ -9,10 +15,11 @@ import {
   Bar,
   Cell,
 } from 'recharts';
-import { useTheme } from 'styled-components';
+import styled, { useTheme } from 'styled-components';
 import { useMediaQuery } from 'react-responsive';
 import { formatNumberAbbreviated } from 'utils/formatter';
 import { queryPhone } from 'styles/breakpoints';
+import { ScrollBar } from 'components/Pages/Core/DappPages/SpiceBazaar/components/CustomScrollBar';
 import type { BarChartProps } from './types';
 
 const DEFAULT_BAR_COLORS = [
@@ -83,84 +90,85 @@ export default function CustomBarChart<T>({
     );
   }, [chartData, yAxisTicks, yDataKey, getYAxisLabel, isPhoneOrAbove]);
 
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (scrollRef.current) {
+      scrollRef.current.scrollLeft = scrollRef.current.scrollWidth;
+    }
+  }, [chartData]);
+
+  const marginLeft = isPhoneOrAbove ? 30 : 0;
+  const marginRight = isPhoneOrAbove ? 30 : 5;
+  const marginTop = 20;
+  const marginBottom = isPhoneOrAbove ? 30 : 35;
+
+  const yAxisChartWidth = yAxisWidth + marginLeft;
+  const minBarWidth = 36;
+  const barCategoryGap = 0.1;
+  const minChartWidth = Math.max(
+    250,
+    Math.ceil(chartData.length * (minBarWidth / (1 - barCategoryGap))) +
+      marginRight
+  );
+
   return (
     <>
-      <ResponsiveContainer minHeight={200} minWidth={250} height={350}>
-        <BarChart
-          data={chartData}
-          barSize={isPhoneOrAbove ? 56 : 24}
-          barCategoryGap={isPhoneOrAbove ? 20 : 10}
-          margin={{
-            left: isPhoneOrAbove ? 40 : 20,
-            top: 20,
-            right: isPhoneOrAbove ? 30 : 5,
-            bottom: isPhoneOrAbove ? 30 : 35,
-          }}
-        >
-          <CartesianGrid
-            horizontal
-            vertical={false}
-            stroke={theme.palette.brandDarker}
-          />
-
-          <XAxis
-            dataKey={xDataKey as string}
-            interval={0}
-            axisLine={false}
-            tickLine={false}
-            tick={({ x, y, payload, index }) => {
-              const formatted = xTickFormatter(payload.value, payload.index);
-              const [line1, line2] = formatted.split(' ');
-              return (
-                <text
-                  key={`x-axis-tick-${payload.value}-${index}`}
-                  x={x}
-                  y={y}
-                  textAnchor={isPhoneOrAbove ? 'middle' : 'end'}
-                  transform={isPhoneOrAbove ? '' : `rotate(-90, ${x}, ${y})`}
-                  fill={theme.palette.brandLight}
-                  fontFamily="Caviar Dreams"
-                  fontSize={12}
-                  fontWeight={700}
-                  letterSpacing="0.05em"
-                >
-                  {isPhoneOrAbove ? (
-                    <>
-                      <tspan x={x} dy="0">
-                        {line1}
-                      </tspan>
-                      <tspan x={x} dy="15">
-                        {line2}
-                      </tspan>
-                    </>
-                  ) : (
-                    formatted
-                  )}
-                </text>
-              );
+      <div style={{ position: 'relative', paddingLeft: '40px' }}>
+        {yAxisTitle && (
+          <div
+            style={{
+              position: 'absolute',
+              left: 0,
+              top: '50%',
+              transform: 'translateY(-50%) rotate(-90deg)',
+              transformOrigin: 'center',
+              whiteSpace: 'nowrap',
+              fontFamily: 'Caviar Dreams',
+              fontSize: isPhoneOrAbove ? '14px' : '12px',
+              fontWeight: 500,
+              letterSpacing: '0.05em',
+              color: theme.palette.brandLight,
             }}
-            minTickGap={10}
-            tickMargin={isPhoneOrAbove ? 30 : 10}
-            padding={{ right: 20 }}
-          />
-
-          <YAxis
-            type="number"
-            scale="linear"
-            domain={yAxisDomain}
-            ticks={yAxisTicks}
-            axisLine={false}
-            tickLine={false}
-            width={yAxisWidth}
-            tick={({ x, y, payload, index }) => {
-              const label = getYAxisLabel(payload.value, index);
-              return (
+          >
+            {yAxisTitle}
+          </div>
+        )}
+        <div style={{ display: 'flex' }}>
+          {/* Fixed Y-axis — never scrolls */}
+          <BarChart
+            width={yAxisChartWidth}
+            height={350}
+            data={chartData}
+            margin={{
+              left: marginLeft,
+              top: marginTop,
+              right: 0,
+              bottom: marginBottom,
+            }}
+          >
+            <XAxis
+              dataKey={xDataKey as string}
+              axisLine={false}
+              tickLine={false}
+              tick={false}
+              tickMargin={isPhoneOrAbove ? 30 : 100}
+            />
+            <YAxis
+              type="number"
+              scale="linear"
+              domain={yAxisDomain}
+              ticks={yAxisTicks}
+              axisLine={false}
+              tickLine={false}
+              width={yAxisWidth}
+              tick={({ x, y, payload, index }) => (
                 <text
                   key={`y-axis-tick-${payload.value}`}
                   x={x}
                   y={y}
                   dy={10}
-                  textAnchor={isPhoneOrAbove ? 'end' : 'middle'}
+                  textAnchor="end"
                   style={{
                     fontSize: '12px',
                     fontWeight: '700',
@@ -171,76 +179,159 @@ export default function CustomBarChart<T>({
                   }}
                 >
                   <tspan x={x} dy={0}>
-                    {label}
+                    {getYAxisLabel(payload.value, index)}
                   </tspan>
                 </text>
-              );
-            }}
-            offset={20}
-            tickMargin={30}
-          />
+              )}
+              offset={20}
+              tickMargin={30}
+            />
+          </BarChart>
 
-          <Tooltip
-            wrapperStyle={{
-              outline: 'none',
-              visibility: activeIndex === null ? 'hidden' : 'visible',
-            }}
-            cursor={false}
-            contentStyle={{
-              background:
-                'linear-gradient(180deg, #353535 45.25%, #101010 87.55%)',
-              boxShadow: '3px 6px 5.5px 0px #00000080',
-              color: theme.palette.brand,
-              borderRadius: '15px',
-              border: 0,
-              padding: '12px 16px',
-              minWidth: isPhoneOrAbove ? '180px' : 'auto',
-              maxWidth: isPhoneOrAbove ? 'none' : '90vw',
-              whiteSpace: 'pre-wrap',
-              wordBreak: 'break-word',
-            }}
-            itemStyle={{
-              background: 'transparent',
-              color: theme.palette.brandLight,
-              fontSize: '12px',
-            }}
-            labelStyle={{
-              background: 'transparent',
-              color: theme.palette.brand,
-              fontSize: '14px',
-            }}
-            labelFormatter={tooltipLabelFormatter}
-            formatter={
-              tooltipValuesFormatter
-                ? (value: any, name: any) =>
-                    tooltipValuesFormatter(value as number, name as string)
-                : undefined
-            }
-          />
-
-          <Bar
-            dataKey={yDataKey as string}
-            radius={[6, 6, 6, 6]}
-            onMouseEnter={(_, index) => setActiveIndex(index)}
-            onMouseLeave={() => setActiveIndex(null)}
+          {/* Scrollable bar area */}
+          <ChartScrollBar
+            autoHide={false}
+            scrollableNodeProps={{ ref: scrollRef }}
           >
-            {chartData.map((entry: T, index) => {
-              const key =
-                typeof entry === 'object' && entry !== null
-                  ? `cell-${String(entry[xDataKey])}`
-                  : `cell-${index}`;
-              return (
-                <Cell
-                  key={key}
-                  fill={barColors[index % barColors.length]}
-                  stroke={index === activeIndex ? '#FFFFFF' : undefined}
-                  strokeWidth={index === activeIndex ? 2 : 0}
-                />
-              );
-            })}
-          </Bar>
-        </BarChart>
-      </ResponsiveContainer>
+            <div style={{ minWidth: minChartWidth }}>
+              <ResponsiveContainer width="100%" height={350}>
+                <BarChart
+                  data={chartData}
+                  margin={{
+                    left: 0,
+                    top: marginTop,
+                    right: marginRight,
+                    bottom: marginBottom,
+                  }}
+                >
+                  <CartesianGrid
+                    horizontal
+                    vertical={false}
+                    stroke={theme.palette.brandDarker}
+                  />
+
+                  <XAxis
+                    dataKey={xDataKey as string}
+                    interval={0}
+                    axisLine={false}
+                    tickLine={false}
+                    tick={({ x, y, payload, index }) => {
+                      const formatted = xTickFormatter(
+                        payload.value,
+                        payload.index
+                      );
+                      const [line1, line2] = formatted.split(' ');
+                      return (
+                        <text
+                          key={`x-axis-tick-${payload.value}-${index}`}
+                          x={x}
+                          y={y}
+                          textAnchor={isPhoneOrAbove ? 'middle' : 'end'}
+                          transform={
+                            isPhoneOrAbove ? '' : `rotate(-90, ${x}, ${y})`
+                          }
+                          fill={theme.palette.brandLight}
+                          fontFamily="Caviar Dreams"
+                          fontSize={12}
+                          fontWeight={700}
+                          letterSpacing="0.05em"
+                        >
+                          {isPhoneOrAbove ? (
+                            <>
+                              <tspan x={x} dy="0">
+                                {line1}
+                              </tspan>
+                              <tspan x={x} dy="15">
+                                {line2}
+                              </tspan>
+                            </>
+                          ) : (
+                            formatted
+                          )}
+                        </text>
+                      );
+                    }}
+                    minTickGap={10}
+                    tickMargin={isPhoneOrAbove ? 30 : 100}
+                    padding={{ right: 20 }}
+                  />
+
+                  <YAxis
+                    hide
+                    width={0}
+                    domain={yAxisDomain}
+                    ticks={yAxisTicks}
+                  />
+
+                  <Tooltip
+                    wrapperStyle={{
+                      outline: 'none',
+                      visibility: activeIndex === null ? 'hidden' : 'visible',
+                    }}
+                    cursor={false}
+                    contentStyle={{
+                      background:
+                        'linear-gradient(180deg, #353535 45.25%, #101010 87.55%)',
+                      boxShadow: '3px 6px 5.5px 0px #00000080',
+                      color: theme.palette.brand,
+                      borderRadius: '15px',
+                      border: 0,
+                      padding: '12px 16px',
+                      minWidth: isPhoneOrAbove ? '180px' : 'auto',
+                      maxWidth: isPhoneOrAbove ? 'none' : '90vw',
+                      whiteSpace: 'pre-wrap',
+                      wordBreak: 'break-word',
+                    }}
+                    itemStyle={{
+                      background: 'transparent',
+                      color: theme.palette.brandLight,
+                      fontSize: '12px',
+                    }}
+                    labelStyle={{
+                      background: 'transparent',
+                      color: theme.palette.brand,
+                      fontSize: '14px',
+                    }}
+                    labelFormatter={tooltipLabelFormatter}
+                    formatter={
+                      tooltipValuesFormatter
+                        ? (value: any, name: any) =>
+                            tooltipValuesFormatter(
+                              value as number,
+                              name as string
+                            )
+                        : undefined
+                    }
+                  />
+
+                  <Bar
+                    dataKey={yDataKey as string}
+                    radius={[6, 6, 6, 6]}
+                    barSize={minBarWidth}
+                    onMouseEnter={(_, index) => setActiveIndex(index)}
+                    onMouseLeave={() => setActiveIndex(null)}
+                  >
+                    {chartData.map((entry: T, index) => {
+                      const key =
+                        typeof entry === 'object' && entry !== null
+                          ? `cell-${String(entry[xDataKey])}`
+                          : `cell-${index}`;
+                      return (
+                        <Cell
+                          key={key}
+                          fill={barColors[index % barColors.length]}
+                          stroke={index === activeIndex ? '#FFFFFF' : undefined}
+                          strokeWidth={index === activeIndex ? 2 : 0}
+                        />
+                      );
+                    })}
+                  </Bar>
+                </BarChart>
+              </ResponsiveContainer>
+            </div>
+          </ChartScrollBar>
+        </div>
+      </div>
       {xAxisTitle && (
         <div
           style={{
@@ -259,3 +350,8 @@ export default function CustomBarChart<T>({
     </>
   );
 }
+
+const ChartScrollBar = styled(ScrollBar)`
+  flex: 1;
+  min-width: 0;
+`;

--- a/apps/dapp/src/components/Pages/Core/DappPages/SpiceBazaar/components/Charts/BarChart.tsx
+++ b/apps/dapp/src/components/Pages/Core/DappPages/SpiceBazaar/components/Charts/BarChart.tsx
@@ -114,24 +114,33 @@ export default function CustomBarChart<T>({
 
   return (
     <>
-      <div style={{ position: 'relative', paddingLeft: '40px' }}>
+      <div style={{ position: 'relative', paddingLeft: '90px' }}>
         {yAxisTitle && (
           <div
             style={{
               position: 'absolute',
               left: 0,
-              top: '50%',
-              transform: 'translateY(-50%) rotate(-90deg)',
-              transformOrigin: 'center',
-              whiteSpace: 'nowrap',
-              fontFamily: 'Caviar Dreams',
-              fontSize: isPhoneOrAbove ? '14px' : '12px',
-              fontWeight: 500,
-              letterSpacing: '0.05em',
-              color: theme.palette.brandLight,
+              top: 0,
+              bottom: 0,
+              width: '90px',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
             }}
           >
-            {yAxisTitle}
+            <div
+              style={{
+                transform: 'rotate(-90deg)',
+                whiteSpace: 'nowrap',
+                fontFamily: 'Caviar Dreams',
+                fontSize: isPhoneOrAbove ? '14px' : '12px',
+                fontWeight: 500,
+                letterSpacing: '0.05em',
+                color: theme.palette.brandLight,
+              }}
+            >
+              {yAxisTitle}
+            </div>
           </div>
         )}
         <div style={{ display: 'flex' }}>

--- a/apps/dapp/src/components/Pages/Core/DappPages/SpiceBazaar/components/Charts/types.ts
+++ b/apps/dapp/src/components/Pages/Core/DappPages/SpiceBazaar/components/Charts/types.ts
@@ -1,3 +1,5 @@
+import React from 'react';
+
 export interface AxisConfig {
   title?: string;
   domain?: [number, number];
@@ -13,7 +15,7 @@ export interface BaseChartProps<T> {
   yAxisDomain?: [number, number];
   yAxisTicks?: number[];
   xTickFormatter: (xValue: any, index?: number) => string;
-  tooltipLabelFormatter: (value: any) => string;
+  tooltipLabelFormatter: (value: any) => React.ReactNode;
   tooltipValuesFormatter?: (
     value: number,
     name: string,

--- a/apps/dapp/src/components/Pages/Core/DappPages/SpiceBazaar/components/InputSelector.tsx
+++ b/apps/dapp/src/components/Pages/Core/DappPages/SpiceBazaar/components/InputSelector.tsx
@@ -86,10 +86,8 @@ export const InputSelect = (props: SelectTempleDaoProps) => {
         <SelectAllRow>
           {props.onSelectAll && (
             <SelectAllButton
-              onMouseDown={(e) => {
-                e.preventDefault();
-                props.onSelectAll!();
-              }}
+              onMouseDown={(e) => e.preventDefault()}
+              onClick={() => props.onSelectAll!()}
             >
               Select All
             </SelectAllButton>
@@ -99,10 +97,8 @@ export const InputSelect = (props: SelectTempleDaoProps) => {
           )}
           {props.onSelectNone && (
             <SelectAllButton
-              onMouseDown={(e) => {
-                e.preventDefault();
-                props.onSelectNone!();
-              }}
+              onMouseDown={(e) => e.preventDefault()}
+              onClick={() => props.onSelectNone!()}
             >
               Select None
             </SelectAllButton>

--- a/apps/dapp/src/components/Pages/Core/DappPages/SpiceBazaar/components/InputSelector.tsx
+++ b/apps/dapp/src/components/Pages/Core/DappPages/SpiceBazaar/components/InputSelector.tsx
@@ -25,6 +25,8 @@ export interface SelectTempleDaoProps {
   fontWeight?: CSS.Property.FontWeight;
   textAlign?: CSS.Property.TextAlign;
   zIndex?: CSS.Property.ZIndex;
+  onSelectAll?: () => void;
+  onSelectNone?: () => void;
 }
 
 const OptionRow = styled.div`
@@ -32,6 +34,25 @@ const OptionRow = styled.div`
   align-items: center;
   gap: 0.5rem;
   color: ${theme.palette.brand};
+`;
+
+const SelectAllRow = styled.div`
+  display: flex;
+  gap: 0.5rem;
+  padding: 0.4rem 0.75rem;
+  border-bottom: 0.0625rem solid ${theme.palette.brand};
+`;
+
+const SelectAllButton = styled.button`
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: ${theme.palette.brand};
+  font-size: 0.75rem;
+  padding: 0;
+  &:hover {
+    color: ${theme.palette.brandLight};
+  }
 `;
 
 const ValueLabel = styled.div`
@@ -58,6 +79,39 @@ export const InputSelect = (props: SelectTempleDaoProps) => {
       </components.Option>
     );
   };
+
+  const CustomMenuList = ({ children, ...menuProps }: any) => (
+    <components.MenuList {...menuProps}>
+      {(props.onSelectAll || props.onSelectNone) && (
+        <SelectAllRow>
+          {props.onSelectAll && (
+            <SelectAllButton
+              onMouseDown={(e) => {
+                e.preventDefault();
+                props.onSelectAll!();
+              }}
+            >
+              Select All
+            </SelectAllButton>
+          )}
+          {props.onSelectAll && props.onSelectNone && (
+            <span style={{ color: theme.palette.brand }}>|</span>
+          )}
+          {props.onSelectNone && (
+            <SelectAllButton
+              onMouseDown={(e) => {
+                e.preventDefault();
+                props.onSelectNone!();
+              }}
+            >
+              Select None
+            </SelectAllButton>
+          )}
+        </SelectAllRow>
+      )}
+      {children}
+    </components.MenuList>
+  );
 
   const CustomValueContainer = ({ children, ...valueProps }: any) => {
     const selected = valueProps.getValue();
@@ -87,6 +141,7 @@ export const InputSelect = (props: SelectTempleDaoProps) => {
       menuPlacement={'auto'}
       components={{
         Option: CustomOption,
+        MenuList: CustomMenuList,
         ValueContainer: CustomValueContainer,
         MultiValue: () => null,
         ClearIndicator: () => null,


### PR DESCRIPTION
With an ever-increasing history of TGLD auctions, the chart X-axis is starting become cramped. This PR adds a scrolling view to the chart for easier readability. 

<img width="2024" height="1092" alt="image" src="https://github.com/user-attachments/assets/5e35cd64-6ef0-426a-8217-b65d38d10248" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Select All" and "Select None" actions to multi-select dropdowns.

* **Improvements**
  * Auction selector shows clearer labels with end date and year; stable time-based ordering and improved default selection on load.
  * Tooltips now show Auction ID and End Date with year and remain visible during touch interactions.

* **UI**
  * Chart layout updated with fixed y-axis and a horizontally scrollable bar area that auto-scrolls to the latest data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->