### PR TITLE
fix: Fix chart and auction details

### DIFF
--- a/apps/dapp/src/components/Pages/Core/DappPages/SpiceBazaar/Spend/Chart/BidHistoryChart.tsx
+++ b/apps/dapp/src/components/Pages/Core/DappPages/SpiceBazaar/Spend/Chart/BidHistoryChart.tsx
@@ -11,21 +11,17 @@ import { Option } from '../../components/InputSelector';
 import { useBidHistory } from '../hooks/use-bid-history';
 
 type BidHistoryChartProps = {
-  auctionTokenAddress?: string;
+  auctionAddress?: string;
   selectedFilters: Option[];
   onFilterOptionsChange?: (options: Option[]) => void;
 };
 
 export const BidHistoryChart = ({
-  auctionTokenAddress,
+  auctionAddress,
   selectedFilters,
   onFilterOptionsChange,
 }: BidHistoryChartProps) => {
-  const {
-    data: historyData,
-    loading,
-    error,
-  } = useBidHistory(auctionTokenAddress);
+  const { data: historyData, loading, error } = useBidHistory(auctionAddress);
 
   // Build available epoch filter options from the data
   const epochOptions: Option[] = useMemo(() => {

--- a/apps/dapp/src/components/Pages/Core/DappPages/SpiceBazaar/Spend/Chart/ChartWrapper.tsx
+++ b/apps/dapp/src/components/Pages/Core/DappPages/SpiceBazaar/Spend/Chart/ChartWrapper.tsx
@@ -113,7 +113,7 @@ export const Charts = ({
       case ChartType.BidHistory:
         return (
           <BidHistoryChart
-            auctionTokenAddress={auctionTokenAddress}
+            auctionAddress={auctionAddress}
             selectedFilters={chartSpecificFilters}
             onFilterOptionsChange={handleBidHistoryOptionsChange}
           />

--- a/apps/dapp/src/components/Pages/Core/DappPages/SpiceBazaar/Spend/Details/Details.tsx
+++ b/apps/dapp/src/components/Pages/Core/DappPages/SpiceBazaar/Spend/Details/Details.tsx
@@ -231,26 +231,14 @@ export const Details = () => {
                           <TimeStampRow>
                             <TimeStampLabel>Start</TimeStampLabel>
                             {state === AuctionState.LIVE ||
-                            state === AuctionState.ENDED ? (
+                            state === AuctionState.ENDED ||
+                            state === AuctionState.SCHEDULED ? (
                               <>
                                 <TimeStampDate>
                                   {formatDate(auction?.auctionStartTime)}
                                 </TimeStampDate>
                                 <TimeStampTime>
                                   {formatTime(auction?.auctionStartTime)}
-                                </TimeStampTime>
-                              </>
-                            ) : auction?.nextAuctionStartTimestamp ? (
-                              <>
-                                <TimeStampDate>
-                                  {formatDate(
-                                    auction.nextAuctionStartTimestamp * 1000
-                                  )}
-                                </TimeStampDate>
-                                <TimeStampTime>
-                                  {formatTime(
-                                    auction.nextAuctionStartTimestamp * 1000
-                                  )}
                                 </TimeStampTime>
                               </>
                             ) : (
@@ -263,7 +251,8 @@ export const Details = () => {
                           <TimeStampRow>
                             <TimeStampLabel>End</TimeStampLabel>
                             {state === AuctionState.LIVE ||
-                            state === AuctionState.ENDED ? (
+                            state === AuctionState.ENDED ||
+                            state === AuctionState.SCHEDULED ? (
                               <>
                                 <TimeStampDate>
                                   {formatDate(auction?.auctionEndTime)}

--- a/apps/dapp/src/components/Pages/Core/DappPages/SpiceBazaar/Spend/hooks/use-bid-history.tsx
+++ b/apps/dapp/src/components/Pages/Core/DappPages/SpiceBazaar/Spend/hooks/use-bid-history.tsx
@@ -38,14 +38,14 @@ type UseBidHistoryReturn = {
  * Groups bids into time buckets from auction start time
  */
 export const useBidHistory = (
-  auctionTokenAddress: string | undefined
+  auctionAddress: string | undefined
 ): UseBidHistoryReturn => {
   const [data, setData] = useState<BidHistoryMetrics[] | null>(null);
   const [loading, setLoading] = useState<boolean>(true);
   const [error, setError] = useState<string | null>(null);
 
   const fetchData = useCallback(async () => {
-    if (!auctionTokenAddress) {
+    if (!auctionAddress) {
       setData([]);
       setError(null);
       setLoading(false);
@@ -73,7 +73,7 @@ export const useBidHistory = (
           while (hasMore) {
             const response = await subgraphQuery(
               entry.url,
-              spiceBidHistoryQuery(auctionTokenAddress, PAGE_SIZE, skip)
+              spiceBidHistoryQuery(auctionAddress, PAGE_SIZE, skip)
             );
 
             if (
@@ -113,6 +113,18 @@ export const useBidHistory = (
         if (!anyEndpointSucceeded) {
           throw lastEndpointError ?? new Error('All subgraph endpoints failed');
         }
+        setData([]);
+        return;
+      }
+
+      // Filter to only bids belonging to this specific auction contract
+      bidTransactions = bidTransactions.filter(
+        (bid: any) =>
+          bid.auctionInstance.spiceAuction?.id?.toLowerCase() ===
+          auctionAddress.toLowerCase()
+      );
+
+      if (bidTransactions.length === 0) {
         setData([]);
         return;
       }
@@ -196,7 +208,7 @@ export const useBidHistory = (
     } finally {
       setLoading(false);
     }
-  }, [auctionTokenAddress]);
+  }, [auctionAddress]);
 
   useEffect(() => {
     fetchData();

--- a/apps/dapp/src/utils/subgraph.ts
+++ b/apps/dapp/src/utils/subgraph.ts
@@ -800,7 +800,7 @@ export type BidsHistoryGoldAuctionResp = z.infer<
 //----------------------------------------------------------------------------------------------------
 
 export function spiceBidHistoryQuery(
-  auctionToken: string,
+  auctionAddress: string,
   first = 1000,
   skip = 0
 ): SubGraphQuery<SpiceBidHistoryResp> {
@@ -815,7 +815,6 @@ export function spiceBidHistoryQuery(
       where: {
         auctionInstance_: {
           auctionType: SpiceAuction
-          auctionToken: "${auctionToken.toLowerCase()}"
         }
       }
     ) {


### PR DESCRIPTION
Two fixes for spice auction details:
- Start and End date showed TBD even when auction countdown was started
- Bid history was incorrectly showing wrong auction data

Note: 
- We will add filtering in the subgraph but client side filtering is OK for now given small amount of data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed bid history filtering to accurately display auction bids
  * Enhanced auction timeline display; start and end times now correctly reflect auction state, showing TBD when times are unavailable

<!-- end of auto-generated comment: release notes by coderabbit.ai -->