### PR TITLE
Misc spice auction detail updates

### DIFF
--- a/apps/dapp/src/components/Pages/Core/DappPages/SpiceBazaar/Spend/Chart/BidHistoryChart.tsx
+++ b/apps/dapp/src/components/Pages/Core/DappPages/SpiceBazaar/Spend/Chart/BidHistoryChart.tsx
@@ -97,7 +97,7 @@ export const BidHistoryChart = ({
         }
         tooltipValuesFormatter={(_value: number, _name: string, props: any) => {
           const d = props.payload;
-          const avg = formatNumberFixedDecimals(d.price, 6);
+          const price = formatNumberFixedDecimals(d.price, 6);
           const total = formatNumberFixedDecimals(d.totalBidAmount, 2);
           const fmt = (n: number, decimals: number) =>
             formatNumberFixedDecimals(n, decimals);
@@ -105,12 +105,7 @@ export const BidHistoryChart = ({
           return [
             `Bids: ${d.count}`,
             `Total Amount: ${total} TGLD`,
-            d.count > 1
-              ? `Avg Price: ${avg} TGLD/${symbol}`
-              : `Price: ${avg} TGLD/${symbol}`,
-            ...(d.count > 1
-              ? [`Price Range: ${fmt(d.minPrice, 6)} – ${fmt(d.maxPrice, 6)}`]
-              : []),
+            `Price: ${price} TGLD/${symbol}`,
           ].join('\n');
         }}
         xAxisTitle="Time"

--- a/apps/dapp/src/components/Pages/Core/DappPages/SpiceBazaar/Spend/Chart/BidHistoryChart.tsx
+++ b/apps/dapp/src/components/Pages/Core/DappPages/SpiceBazaar/Spend/Chart/BidHistoryChart.tsx
@@ -12,16 +12,22 @@ import { useBidHistory } from '../hooks/use-bid-history';
 
 type BidHistoryChartProps = {
   auctionAddress?: string;
+  totalAuctionTokenAmount?: number;
   selectedFilters: Option[];
   onFilterOptionsChange?: (options: Option[]) => void;
 };
 
 export const BidHistoryChart = ({
   auctionAddress,
+  totalAuctionTokenAmount,
   selectedFilters,
   onFilterOptionsChange,
 }: BidHistoryChartProps) => {
-  const { data: historyData, loading, error } = useBidHistory(auctionAddress);
+  const {
+    data: historyData,
+    loading,
+    error,
+  } = useBidHistory(auctionAddress, totalAuctionTokenAmount);
 
   // Build available epoch filter options from the data
   const epochOptions: Option[] = useMemo(() => {

--- a/apps/dapp/src/components/Pages/Core/DappPages/SpiceBazaar/Spend/Chart/ChartWrapper.tsx
+++ b/apps/dapp/src/components/Pages/Core/DappPages/SpiceBazaar/Spend/Chart/ChartWrapper.tsx
@@ -12,6 +12,7 @@ import { BidHistoryChart } from './BidHistoryChart';
 type ChartsProps = {
   auctionAddress: string;
   auctionTokenAddress?: string;
+  totalAuctionTokenAmount?: number;
 };
 
 // Chart type options for the first dropdown
@@ -24,6 +25,7 @@ enum ChartType {
 export const Charts = ({
   auctionAddress,
   auctionTokenAddress,
+  totalAuctionTokenAmount,
 }: ChartsProps) => {
   // First dropdown: Chart type selection
   const chartTypeOptions: Option[] = useMemo(
@@ -114,6 +116,7 @@ export const Charts = ({
         return (
           <BidHistoryChart
             auctionAddress={auctionAddress}
+            totalAuctionTokenAmount={totalAuctionTokenAmount}
             selectedFilters={chartSpecificFilters}
             onFilterOptionsChange={handleBidHistoryOptionsChange}
           />

--- a/apps/dapp/src/components/Pages/Core/DappPages/SpiceBazaar/Spend/Details/Details.tsx
+++ b/apps/dapp/src/components/Pages/Core/DappPages/SpiceBazaar/Spend/Details/Details.tsx
@@ -139,6 +139,7 @@ export const Details = () => {
       <Charts
         auctionAddress={auction.address}
         auctionTokenAddress={tokenAddress}
+        totalAuctionTokenAmount={auction.totalAuctionTokenAmount}
       />
     );
   }, [auction?.address, auction?.staticConfig?.auctionToken?.address]);

--- a/apps/dapp/src/components/Pages/Core/DappPages/SpiceBazaar/Spend/hooks/use-bid-history.tsx
+++ b/apps/dapp/src/components/Pages/Core/DappPages/SpiceBazaar/Spend/hooks/use-bid-history.tsx
@@ -117,18 +117,6 @@ export const useBidHistory = (
         return;
       }
 
-      // Filter to only bids belonging to this specific auction contract
-      bidTransactions = bidTransactions.filter(
-        (bid: any) =>
-          bid.auctionInstance.spiceAuction?.id?.toLowerCase() ===
-          auctionAddress.toLowerCase()
-      );
-
-      if (bidTransactions.length === 0) {
-        setData([]);
-        return;
-      }
-
       // Group bids by epoch
       const bidsByEpoch = new Map<string, any[]>();
       bidTransactions.forEach((bid: any) => {

--- a/apps/dapp/src/components/Pages/Core/DappPages/SpiceBazaar/Spend/hooks/use-bid-history.tsx
+++ b/apps/dapp/src/components/Pages/Core/DappPages/SpiceBazaar/Spend/hooks/use-bid-history.tsx
@@ -38,7 +38,8 @@ type UseBidHistoryReturn = {
  * Groups bids into time buckets from auction start time
  */
 export const useBidHistory = (
-  auctionAddress: string | undefined
+  auctionAddress: string | undefined,
+  totalAuctionTokenAmount: number | undefined
 ): UseBidHistoryReturn => {
   const [data, setData] = useState<BidHistoryMetrics[] | null>(null);
   const [loading, setLoading] = useState<boolean>(true);
@@ -148,7 +149,9 @@ export const useBidHistory = (
           const bucketLabel = `${bucketStart}-${bucketEnd}h`;
 
           return {
-            price: parseFloat(bid.price),
+            price: totalAuctionTokenAmount
+              ? parseFloat(bid.bidAmount) / totalAuctionTokenAmount
+              : 0,
             bidAmount: bid.bidAmount,
             hash: bid.hash,
             timestamp: bidTimestamp,
@@ -159,11 +162,19 @@ export const useBidHistory = (
           };
         });
 
-        // Mark only the very last bid of the entire epoch as final
         if (processedBids.length > 0) {
-          // Sort by timestamp to find the last bid
           processedBids.sort((a, b) => a.timestamp - b.timestamp);
-          // Mark only the last bid of the epoch
+
+          // Replace per-bid price with running cumulative TGLD/ENA ratio
+          // (each bid's price = bidAmount/totalAuctionTokenAmount, so the
+          // cumulative sum equals totalBidTokenAmount/totalAuctionTokenAmount
+          // at that point in time — matching the "1 TOKEN = X TGLD" display)
+          let cumulative = 0;
+          processedBids.forEach((bid) => {
+            cumulative += bid.price;
+            bid.price = cumulative;
+          });
+
           processedBids[processedBids.length - 1].isFinalBid = true;
         }
 
@@ -196,7 +207,7 @@ export const useBidHistory = (
     } finally {
       setLoading(false);
     }
-  }, [auctionAddress]);
+  }, [auctionAddress, totalAuctionTokenAmount]);
 
   useEffect(() => {
     fetchData();

--- a/apps/dapp/src/components/Pages/Core/DappPages/SpiceBazaar/components/Charts/bidAggregation.ts
+++ b/apps/dapp/src/components/Pages/Core/DappPages/SpiceBazaar/components/Charts/bidAggregation.ts
@@ -79,7 +79,7 @@ export function aggregateBidsByBucket(
     .map((b) => ({
       bucket: b.bucket,
       bucketIndex: b.bucketIndex,
-      price: b.prices.reduce((sum, p) => sum + p, 0) / b.prices.length,
+      price: Math.max(...b.prices),
       minPrice: Math.min(...b.prices),
       maxPrice: Math.max(...b.prices),
       totalBidAmount: b.totalBidAmount,

--- a/apps/dapp/src/utils/subgraph.ts
+++ b/apps/dapp/src/utils/subgraph.ts
@@ -813,9 +813,7 @@ export function spiceBidHistoryQuery(
       first: ${first}
       skip: ${skip}
       where: {
-        auctionInstance_: {
-          auctionType: SpiceAuction
-        }
+        auctionInstance_starts_with: "${auctionAddress.toLowerCase()}"
       }
     ) {
       price


### PR DESCRIPTION
Follow up from this PR https://github.com/TempleDAO/temple/pull/1272

We can actually do this in the subgraph, so update the query and remove the client side filtering.

Changes:

- Add subgraph filtering remove client side filter
- Update spice auction dot chart so it displays in TGLD price terms (not the spice token)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Restored complete bid retrieval so bid history shows all relevant bids for the selected auction.

* **New Features**
  * Prices are calculated relative to the auction’s total token amount and shown as a running (cumulative) value per epoch; final bids remain highlighted.
  * Chart components now accept auction token totals for accurate price rendering.
  * Tooltips simplified to always show Bids, Total Amount, and Price for each epoch.

* **Refactor**
  * Query filtering and bucket aggregation updated to improve consistency and use peak price per bucket.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TempleDAO/temple/pull/1274)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->